### PR TITLE
Persist variant annotations in Kudu.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/check/Gen.scala
+++ b/src/main/scala/org/broadinstitute/hail/check/Gen.scala
@@ -214,6 +214,8 @@ object Gen {
     p.rng.getRandomGenerator.nextBoolean()
   }
 
+  def arbByte: Gen[Byte] = Gen { p => p.rng.getRandomGenerator.nextInt().toByte }
+
   def arbInt: Gen[Int] = Gen { p => p.rng.getRandomGenerator.nextInt() }
 
   def arbLong: Gen[Long] = Gen { p => p.rng.getRandomGenerator.nextLong() }

--- a/src/main/scala/org/broadinstitute/hail/expr/AnnotationImpex.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/AnnotationImpex.scala
@@ -26,6 +26,22 @@ object SparkAnnotationImpex extends AnnotationImpex[DataType, Any] {
     case _ => false
   }
 
+  def importType(t: DataType): Type = t match {
+    case BooleanType => TBoolean
+    case IntegerType => TInt
+    case LongType => TLong
+    case FloatType => TFloat
+    case DoubleType => TDouble
+    case StringType => TString
+    case BinaryType => TBinary
+    case ArrayType(elementType, _) => TArray(importType(elementType))
+    case StructType(fields) =>
+      TStruct(fields.zipWithIndex
+        .map { case (f, i) =>
+          (f.name, importType(f.dataType))
+        }: _*)
+  }
+
   def importAnnotation(a: Any, t: Type): Annotation = {
     if (a == null)
       null
@@ -74,6 +90,7 @@ object SparkAnnotationImpex extends AnnotationImpex[DataType, Any] {
     case TDouble => DoubleType
     case TString => StringType
     case TChar => StringType
+    case TBinary => BinaryType
     case TArray(elementType) => ArrayType(exportType(elementType))
     case TSet(elementType) => ArrayType(exportType(elementType))
     case TDict(elementType) =>
@@ -90,8 +107,9 @@ object SparkAnnotationImpex extends AnnotationImpex[DataType, Any] {
       else
         StructType(fields
           .map(f =>
-            // FIXME StructField(f.name, f.`type`.schema)
-            StructField(f.index.toString, f.`type`.schema)
+            // FIXME
+            StructField(f.name, f.`type`.schema)
+            // StructField(f.index.toString, f.`type`.schema)
           ))
   }
 

--- a/src/main/scala/org/broadinstitute/hail/expr/Type.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/Type.scala
@@ -111,6 +111,14 @@ abstract class Type extends BaseType {
   def genValue: Gen[Annotation] = Gen.const(Annotation.empty)
 }
 
+case object TBinary extends Type {
+  override def toString = "Binary"
+
+  def typeCheck(a: Any): Boolean = a == null || a.isInstanceOf[Array[Byte]]
+
+  override def genValue: Gen[Annotation] = Gen.buildableOf[Array[Byte], Byte](Gen.arbByte)
+}
+
 case object TBoolean extends Type with Parsable {
   override def toString = "Boolean"
 

--- a/src/main/scala/org/broadinstitute/hail/variant/GenotypeStream.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/GenotypeStream.scala
@@ -8,6 +8,8 @@ import org.broadinstitute.hail.ByteIterator
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 import org.broadinstitute.hail.Utils._
+import org.broadinstitute.hail.expr.{TBinary, TInt, TStruct, Type}
+
 import scala.collection.mutable
 
 // FIXME use zipWithIndex
@@ -90,6 +92,9 @@ object GenotypeStream {
       StructField("bytes", BinaryType, nullable = false)
     ))
   }
+
+  def t: Type = TStruct("decompLen" -> TInt,
+    "bytes" -> TBinary)
 
   def fromRow(v: Variant, row: Row): GenotypeStream = {
 

--- a/src/main/scala/org/broadinstitute/hail/variant/KuduUtils.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/KuduUtils.scala
@@ -3,36 +3,50 @@ package org.broadinstitute.hail.variant
 import java.util.ArrayList
 
 import htsjdk.samtools.SAMSequenceDictionary
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
 import org.kududb.ColumnSchema.ColumnSchemaBuilder
 import org.kududb.{ColumnSchema, Schema, Type}
 import org.kududb.client.{CreateTableOptions, KuduClient}
 
 import scala.collection.JavaConversions._
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
 
 object KuduUtils {
 
-  def normalizeContig(contig: String): String = {
-    "%2s".format(contig.replace("chr", ""))
+  def toKuduSchema(schema: StructType, keys: Seq[String]): Schema = {
+    val kuduCols = new ArrayList[ColumnSchema]()
+    // add the key columns first, in the order specified
+    for (key <- keys) {
+      val f = schema.fields(schema.fieldIndex(key))
+      kuduCols.add(new ColumnSchema.ColumnSchemaBuilder(f.name, kuduType(f.dataType)).key(true).build())
+    }
+    // now add the non-key columns
+    for (f <- schema.fields.filter(field=> !keys.contains(field.name))) {
+      kuduCols.add(new ColumnSchema.ColumnSchemaBuilder(f.name, kuduType(f.dataType)).nullable(f.nullable).key(false).build())
+    }
+    new Schema(kuduCols)
   }
 
-  def buildSchema(): Schema = {
-    val cols = new ArrayList[ColumnSchema]
-    cols.add(new ColumnSchemaBuilder("contig_norm", Type.STRING).key(true).build)
-    cols.add(new ColumnSchemaBuilder("start", Type.INT32).key(true).build)
-    cols.add(new ColumnSchemaBuilder("ref", Type.STRING).key(true).build)
-    cols.add(new ColumnSchemaBuilder("alt", Type.STRING).key(true).build)
-    cols.add(new ColumnSchemaBuilder("sample_group", Type.STRING).key(true).build)
-    cols.add(new ColumnSchemaBuilder("contig", Type.STRING).build)
-    cols.add(new ColumnSchemaBuilder("annotations", Type.BINARY).nullable(true).build)
-    cols.add(new ColumnSchemaBuilder("genotypes_byte_len", Type.INT32).nullable(true).build)
-    cols.add(new ColumnSchemaBuilder("genotypes", Type.BINARY).nullable(true).build)
-    new Schema(cols)
+  def kuduType(dt: DataType) : Type = dt match {
+    case DataTypes.BinaryType => Type.BINARY
+    case DataTypes.BooleanType => Type.BOOL
+    case DataTypes.StringType => Type.STRING
+    case DataTypes.TimestampType => Type.TIMESTAMP
+    case DataTypes.ByteType => Type.INT8
+    case DataTypes.ShortType => Type.INT16
+    case DataTypes.IntegerType => Type.INT32
+    case DataTypes.LongType => Type.INT64
+    case DataTypes.FloatType => Type.FLOAT
+    case DataTypes.DoubleType => Type.DOUBLE
+    case _ => throw new IllegalArgumentException(s"No support for Spark SQL type $dt")
   }
 
-  def createTableOptions(schema: Schema, seqDict: SAMSequenceDictionary, rowsPerPartition: Int): CreateTableOptions = {
+  def createTableOptions(schema: StructType, keys: Seq[String], seqDict: SAMSequenceDictionary, rowsPerPartition: Int): CreateTableOptions = {
     val rangePartitionCols = new ArrayList[String]
-    rangePartitionCols.add("contig_norm")
-    rangePartitionCols.add("start")
+    rangePartitionCols.add("variant__contig")
+    rangePartitionCols.add("variant__start")
     val options = new CreateTableOptions().setRangePartitionColumns(rangePartitionCols)
     // e.g. if rowsPerPartition is 10000000 then create split points at
     // (' 1', 0), (' 1', 10000000), (' 1', 20000000), ... (' 1', 240000000)
@@ -40,28 +54,22 @@ object KuduUtils {
     // ...
     // (' Y', 0), (' Y', 10000000), (' Y', 20000000), ... (' Y', 50000000)
     seqDict.getSequences.flatMap(seq => {
-      val contig = normalizeContig(seq.getSequenceName)
+      val contig = seq.getSequenceName
       val length = seq.getSequenceLength
       Range(0, 1 + length/rowsPerPartition).toList.map(pos => (contig, pos*rowsPerPartition))
     }).map(kv => {
-      val partialRow = schema.newPartialRow()
-      partialRow.addString("contig_norm", kv._1)
-      partialRow.addInt("start", kv._2)
+      val partialRow = toKuduSchema(schema, keys).newPartialRow()
+      partialRow.addString("variant__contig", kv._1)
+      partialRow.addInt("variant__start", kv._2)
       options.addSplitRow(partialRow)
     })
     options
   }
 
-  def createTableIfNecessary(masterAddress: String, tableName: String,
-                             seqDict: SAMSequenceDictionary, rowsPerPartition: Int) {
+  def tableExists(masterAddress: String, tableName: String): Boolean = {
     val client = new KuduClient.KuduClientBuilder(masterAddress).build
     try {
-      if (!client.tableExists(tableName)) {
-        println("Table " + tableName + " does not exist")
-        val schema = buildSchema()
-        client.createTable(tableName, schema, createTableOptions(schema, seqDict, rowsPerPartition))
-        println("Table " + tableName + " created")
-      }
+      return client.tableExists(tableName)
     } finally {
       client.close()
     }
@@ -76,6 +84,77 @@ object KuduUtils {
       }
     } finally {
       client.close()
+    }
+  }
+
+  val fixedArraySize = 2
+
+  def flatten(schema: StructType): StructType = {
+    StructType(flattenFields(schema, "", ListBuffer[StructField]()))
+  }
+
+  private def flattenFields(schema: StructType, prefix: String, acc: Seq[StructField]): Seq[StructField] = {
+    schema.flatMap(field => field.dataType match {
+      case st: StructType => flattenFields(st, prefix + field.name + "__", acc)
+      case at: ArrayType => at.elementType match {
+        case st: StructType => Range(0, fixedArraySize).flatMap(a =>
+          flattenFields(makeNullable(st), prefix + field.name + "_" + a + "__", acc)
+        )
+        case _ => Range(0, fixedArraySize).map(a =>
+          StructField(prefix + field.name + "_" + a, at.elementType, nullable = true, field.metadata)
+        )
+      }
+      case mt: MapType =>
+        throw new IllegalArgumentException("Cannot flatten MapType")
+      case _ => Some(field.copy(name = prefix + field.name))
+    })
+  }
+
+  private def makeNullable(st: StructType): StructType = {
+    st.copy(st.fields.map(f => f.copy(nullable = true)))
+  }
+
+  def flatten(row: Row, schema: StructType): Row = {
+    Row.fromSeq(flattenElements(row, schema, ListBuffer[Any]()))
+  }
+
+  private def flattenElements(row: Row, schema: StructType, acc: Seq[Any]): Seq[Any] = {
+    schema.flatMap(field => field.dataType match {
+      case st: StructType => flattenElements(row.getStruct(schema.fieldIndex(field
+        .name)), st, acc)
+      case at: ArrayType => at.elementType match {
+        case st: StructType => row.getAs[Seq[Row]](schema.fieldIndex(field.name))
+          .take(fixedArraySize).padTo(fixedArraySize, null)
+          .flatMap(a => flattenElements(a, st, acc))
+        case _ => row.getSeq(schema.fieldIndex(field.name))
+          .take(fixedArraySize).padTo(fixedArraySize, null)
+      }
+      case mt: MapType =>
+        throw new IllegalArgumentException("Cannot flatten MapType")
+      case _ => if (row == null) Some(null) else Some(row.get(schema.fieldIndex(field.name)))
+    })
+  }
+
+  def unflatten(row: Row, schema: StructType): Row = {
+    val it = row.toSeq.iterator
+    Row.fromSeq(schema.fields.map(f => consume(it, f.dataType)))
+  }
+
+  def reorder(row: Row, indices: Array[Int]): Row = {
+    val values: Seq[Any] = row.toSeq
+    Row.fromSeq(for (i <- List.range(0, values.length)) yield values(indices(i)))
+  }
+
+  private def consume(stream: Iterator[Any], dataType: DataType): Any = {
+    dataType match {
+      case st: StructType => {
+        val values = st.fields.map(f => consume(stream, f.dataType))
+        if (values.forall(_ == null)) null else Row.fromSeq(values)
+      }
+      case at: ArrayType => mutable.WrappedArray.make(
+        Range(0, fixedArraySize).toArray
+        .map(f => consume(stream, at.elementType)).filter(_ != null))
+      case _ => stream.next()
     }
   }
 

--- a/src/main/scala/org/broadinstitute/hail/variant/KuduUtils.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/KuduUtils.scala
@@ -5,7 +5,9 @@ import java.util.ArrayList
 import htsjdk.samtools.SAMSequenceDictionary
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
-import org.kududb.ColumnSchema.ColumnSchemaBuilder
+import org.broadinstitute.hail.annotations.Annotation
+import org.broadinstitute.hail.expr.{AnnotationImpex, SparkAnnotationImpex}
+import org.broadinstitute.hail.expr
 import org.kududb.{ColumnSchema, Schema, Type}
 import org.kududb.client.{CreateTableOptions, KuduClient}
 
@@ -13,84 +15,19 @@ import scala.collection.JavaConversions._
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
-object KuduUtils {
+object KuduAnnotationImpex extends AnnotationImpex[DataType, Any] {
+  def exportType(t: expr.Type): DataType = flatten(SparkAnnotationImpex.exportType(t))
 
-  def toKuduSchema(schema: StructType, keys: Seq[String]): Schema = {
-    val kuduCols = new ArrayList[ColumnSchema]()
-    // add the key columns first, in the order specified
-    for (key <- keys) {
-      val f = schema.fields(schema.fieldIndex(key))
-      kuduCols.add(new ColumnSchema.ColumnSchemaBuilder(f.name, kuduType(f.dataType)).key(true).build())
-    }
-    // now add the non-key columns
-    for (f <- schema.fields.filter(field=> !keys.contains(field.name))) {
-      kuduCols.add(new ColumnSchema.ColumnSchemaBuilder(f.name, kuduType(f.dataType)).nullable(f.nullable).key(false).build())
-    }
-    new Schema(kuduCols)
-  }
+  def exportAnnotation(a: Annotation, t: expr.Type): Any = flatten(SparkAnnotationImpex.exportAnnotation(a, t), t)
 
-  def kuduType(dt: DataType) : Type = dt match {
-    case DataTypes.BinaryType => Type.BINARY
-    case DataTypes.BooleanType => Type.BOOL
-    case DataTypes.StringType => Type.STRING
-    case DataTypes.TimestampType => Type.TIMESTAMP
-    case DataTypes.ByteType => Type.INT8
-    case DataTypes.ShortType => Type.INT16
-    case DataTypes.IntegerType => Type.INT32
-    case DataTypes.LongType => Type.INT64
-    case DataTypes.FloatType => Type.FLOAT
-    case DataTypes.DoubleType => Type.DOUBLE
-    case _ => throw new IllegalArgumentException(s"No support for Spark SQL type $dt")
-  }
-
-  def createTableOptions(schema: StructType, keys: Seq[String], seqDict: SAMSequenceDictionary, rowsPerPartition: Int): CreateTableOptions = {
-    val rangePartitionCols = new ArrayList[String]
-    rangePartitionCols.add("variant__contig")
-    rangePartitionCols.add("variant__start")
-    val options = new CreateTableOptions().setRangePartitionColumns(rangePartitionCols)
-    // e.g. if rowsPerPartition is 10000000 then create split points at
-    // (' 1', 0), (' 1', 10000000), (' 1', 20000000), ... (' 1', 240000000)
-    // (' 2', 0), (' 2', 10000000), (' 2', 20000000), ... (' 2', 240000000)
-    // ...
-    // (' Y', 0), (' Y', 10000000), (' Y', 20000000), ... (' Y', 50000000)
-    seqDict.getSequences.flatMap(seq => {
-      val contig = seq.getSequenceName
-      val length = seq.getSequenceLength
-      Range(0, 1 + length/rowsPerPartition).toList.map(pos => (contig, pos*rowsPerPartition))
-    }).map(kv => {
-      val partialRow = toKuduSchema(schema, keys).newPartialRow()
-      partialRow.addString("variant__contig", kv._1)
-      partialRow.addInt("variant__start", kv._2)
-      options.addSplitRow(partialRow)
-    })
-    options
-  }
-
-  def tableExists(masterAddress: String, tableName: String): Boolean = {
-    val client = new KuduClient.KuduClientBuilder(masterAddress).build
-    try {
-      return client.tableExists(tableName)
-    } finally {
-      client.close()
-    }
-  }
-
-  def dropTable(masterAddress: String, tableName: String) {
-    val client = new KuduClient.KuduClientBuilder(masterAddress).build
-    try {
-      if (client.tableExists(tableName)) {
-        println("Dropping table " + tableName)
-        client.deleteTable(tableName)
-      }
-    } finally {
-      client.close()
-    }
-  }
+  def importAnnotation(a: Any, t: expr.Type): Annotation =
+    SparkAnnotationImpex.importAnnotation(unflatten(a, t), t)
 
   val fixedArraySize = 2
 
-  def flatten(schema: StructType): StructType = {
-    StructType(flattenFields(schema, "", ListBuffer[StructField]()))
+  def flatten(dt: DataType): DataType = dt match {
+    case st: StructType => StructType(flattenFields(st, "", ListBuffer[StructField]()))
+    case _ => dt
   }
 
   private def flattenFields(schema: StructType, prefix: String, acc: Seq[StructField]): Seq[StructField] = {
@@ -114,30 +51,32 @@ object KuduUtils {
     st.copy(st.fields.map(f => f.copy(nullable = true)))
   }
 
-  def flatten(row: Row, schema: StructType): Row = {
-    Row.fromSeq(flattenElements(row, schema, ListBuffer[Any]()))
+  def flatten(a: Any, t: expr.Type): Any = t match {
+    case st: expr.TStruct => Row.fromSeq(flattenElements(a.asInstanceOf[Row], st, ListBuffer[Any]()))
+    case _ => a
   }
 
-  private def flattenElements(row: Row, schema: StructType, acc: Seq[Any]): Seq[Any] = {
-    schema.flatMap(field => field.dataType match {
-      case st: StructType => flattenElements(row.getStruct(schema.fieldIndex(field
-        .name)), st, acc)
-      case at: ArrayType => at.elementType match {
-        case st: StructType => row.getAs[Seq[Row]](schema.fieldIndex(field.name))
+  private def flattenElements(row: Row, t: expr.TStruct, acc: Seq[Any]): Seq[Any] = {
+    t.fields.flatMap(field => field.`type` match {
+      case st: expr.TStruct => flattenElements(row.getStruct(field.index), st, acc)
+      case at: expr.TIterable => at.elementType match {
+        case st: expr.TStruct => row.getAs[Seq[Row]](field.index)
           .take(fixedArraySize).padTo(fixedArraySize, null)
           .flatMap(a => flattenElements(a, st, acc))
-        case _ => row.getSeq(schema.fieldIndex(field.name))
+        case _ => row.getSeq(field.index)
           .take(fixedArraySize).padTo(fixedArraySize, null)
       }
-      case mt: MapType =>
+      case mt: expr.TDict =>
         throw new IllegalArgumentException("Cannot flatten MapType")
-      case _ => if (row == null) Some(null) else Some(row.get(schema.fieldIndex(field.name)))
+      case _ => if (row == null) Some(null) else Some(row.get(field.index))
     })
   }
 
-  def unflatten(row: Row, schema: StructType): Row = {
-    val it = row.toSeq.iterator
-    Row.fromSeq(schema.fields.map(f => consume(it, f.dataType)))
+  def unflatten(a: Annotation, t: expr.Type): Any = t match {
+    case st: expr.TStruct =>
+      val row = a.asInstanceOf[Row]
+      val it = row.toSeq.iterator
+      Row.fromSeq(st.fields.map(f => consume(it, f.`type`)))
   }
 
   def reorder(row: Row, indices: Array[Int]): Row = {
@@ -145,16 +84,90 @@ object KuduUtils {
     Row.fromSeq(for (i <- List.range(0, values.length)) yield values(indices(i)))
   }
 
-  private def consume(stream: Iterator[Any], dataType: DataType): Any = {
-    dataType match {
-      case st: StructType => {
-        val values = st.fields.map(f => consume(stream, f.dataType))
+  private def consume(stream: Iterator[Any], t: expr.Type): Any = {
+    t match {
+      case st: expr.TStruct =>
+        val values = st.fields.map(f => consume(stream, f.`type`))
         if (values.forall(_ == null)) null else Row.fromSeq(values)
-      }
-      case at: ArrayType => mutable.WrappedArray.make(
+      case at: expr.TIterable => mutable.WrappedArray.make(
         Range(0, fixedArraySize).toArray
-        .map(f => consume(stream, at.elementType)).filter(_ != null))
+          .map(f => consume(stream, at.elementType)).filter(_ != null))
       case _ => stream.next()
+    }
+  }
+}
+
+object KuduUtils {
+
+  def toKuduSchema(schema: StructType, keys: Seq[String]): Schema = {
+    val kuduCols = new ArrayList[ColumnSchema]()
+    // add the key columns first, in the order specified
+    for (key <- keys) {
+      val f = schema.fields(schema.fieldIndex(key))
+      kuduCols.add(new ColumnSchema.ColumnSchemaBuilder(f.name, kuduType(f.dataType)).key(true).build())
+    }
+    // now add the non-key columns
+    for (f <- schema.fields.filter(field => !keys.contains(field.name))) {
+      kuduCols.add(new ColumnSchema.ColumnSchemaBuilder(f.name, kuduType(f.dataType)).nullable(f.nullable).key(false).build())
+    }
+    new Schema(kuduCols)
+  }
+
+  def kuduType(dt: DataType): Type = dt match {
+    case DataTypes.BinaryType => Type.BINARY
+    case DataTypes.BooleanType => Type.BOOL
+    case DataTypes.StringType => Type.STRING
+    case DataTypes.TimestampType => Type.TIMESTAMP
+    case DataTypes.ByteType => Type.INT8
+    case DataTypes.ShortType => Type.INT16
+    case DataTypes.IntegerType => Type.INT32
+    case DataTypes.LongType => Type.INT64
+    case DataTypes.FloatType => Type.FLOAT
+    case DataTypes.DoubleType => Type.DOUBLE
+    case _ => throw new IllegalArgumentException(s"No support for Spark SQL type $dt")
+  }
+
+  def createTableOptions(schema: StructType, keys: Seq[String], seqDict: SAMSequenceDictionary, rowsPerPartition: Int): CreateTableOptions = {
+    val rangePartitionCols = new ArrayList[String]
+    rangePartitionCols.add("variant__contig")
+    rangePartitionCols.add("variant__start")
+    val options = new CreateTableOptions().setRangePartitionColumns(rangePartitionCols)
+    // e.g. if rowsPerPartition is 10000000 then create split points at
+    // (' 1', 0), (' 1', 10000000), (' 1', 20000000), ... (' 1', 240000000)
+    // (' 2', 0), (' 2', 10000000), (' 2', 20000000), ... (' 2', 240000000)
+    // ...
+    // (' Y', 0), (' Y', 10000000), (' Y', 20000000), ... (' Y', 50000000)
+    seqDict.getSequences.flatMap { seq =>
+      val contig = seq.getSequenceName
+      val length = seq.getSequenceLength
+      Range(0, 1 + length / rowsPerPartition).map(pos => (contig, pos * rowsPerPartition))
+    }.map { case (contig, start) =>
+      val partialRow = toKuduSchema(schema, keys).newPartialRow()
+      partialRow.addString("variant__contig", contig)
+      partialRow.addInt("variant__start", start)
+      options.addSplitRow(partialRow)
+    }
+    options
+  }
+
+  def tableExists(masterAddress: String, tableName: String): Boolean = {
+    val client = new KuduClient.KuduClientBuilder(masterAddress).build
+    try {
+      client.tableExists(tableName)
+    } finally {
+      client.close()
+    }
+  }
+
+  def dropTable(masterAddress: String, tableName: String) {
+    val client = new KuduClient.KuduClientBuilder(masterAddress).build
+    try {
+      if (client.tableExists(tableName)) {
+        println("Dropping table " + tableName)
+        client.deleteTable(tableName)
+      }
+    } finally {
+      client.close()
     }
   }
 

--- a/src/test/scala/org/broadinstitute/hail/annotations/AnnotationsSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/annotations/AnnotationsSuite.scala
@@ -161,7 +161,7 @@ class AnnotationsSuite extends SparkSuite {
     vds = vds.mapAnnotations((v, va, gs) => i1(va, Some(toAdd)))
       .copy(vaSignature = s1)
     assert(vds.vaSignature.schema ==
-      StructType(Array(StructField("0", IntegerType))))
+      StructType(Array(StructField("I1", IntegerType))))
 
     val q1 = vds.queryVA("va.I1")._2
     assert(vds.variantsAndAnnotations
@@ -176,8 +176,8 @@ class AnnotationsSuite extends SparkSuite {
       .copy(vaSignature = s2)
     assert(vds.vaSignature.schema ==
       StructType(Array(
-        StructField("0", IntegerType),
-        StructField("1", StringType))))
+        StructField("I1", IntegerType),
+        StructField("S1", StringType))))
 
     val q2 = vds.queryVA("va.S1")._2
     assert(vds.variantsAndAnnotations
@@ -193,11 +193,11 @@ class AnnotationsSuite extends SparkSuite {
       .copy(vaSignature = s3)
     assert(vds.vaSignature.schema ==
       StructType(Array(
-        StructField("0", StructType(Array(
-          StructField("0", IntegerType, nullable = true),
-          StructField("1", IntegerType, nullable = true)
+        StructField("I1", StructType(Array(
+          StructField("I2", IntegerType, nullable = true),
+          StructField("I3", IntegerType, nullable = true)
         )), nullable = true),
-        StructField("1", StringType))))
+        StructField("S1", StringType))))
 
     val q3 = vds.queryVA("va.I1")._2
     val q4 = vds.queryVA("va.I1.I2")._2
@@ -218,13 +218,13 @@ class AnnotationsSuite extends SparkSuite {
       .copy(vaSignature = s4)
     assert(vds.vaSignature.schema ==
       StructType(Array(
-        StructField("0", toAdd3Sig.schema),
-        StructField("1", StringType),
-        StructField("2", StructType(Array(
-          StructField("0", StructType(Array(
-            StructField("0", StructType(Array(
-              StructField("0", StructType(Array(
-                StructField("0", StringType))))))))))))))))
+        StructField("I1", toAdd3Sig.schema),
+        StructField("S1", StringType),
+        StructField("a", StructType(Array(
+          StructField("b", StructType(Array(
+            StructField("c", StructType(Array(
+              StructField("d", StructType(Array(
+                StructField("e", StringType))))))))))))))))
 
     val q6 = vds.queryVA("va.a.b.c.d.e")._2
     assert(vds.variantsAndAnnotations
@@ -240,14 +240,14 @@ class AnnotationsSuite extends SparkSuite {
 
     assert(vds.vaSignature.schema ==
       StructType(Array(
-        StructField("0", toAdd3Sig.schema),
-        StructField("1", StringType),
-        StructField("2", StructType(Array(
-          StructField("0", StructType(Array(
-            StructField("0", StructType(Array(
-              StructField("0", StructType(Array(
-                StructField("0", StringType)))),
-              StructField("1", StringType)))))))))))))
+        StructField("I1", toAdd3Sig.schema),
+        StructField("S1", StringType),
+        StructField("a", StructType(Array(
+          StructField("b", StructType(Array(
+            StructField("c", StructType(Array(
+              StructField("d", StructType(Array(
+                StructField("e", StringType)))),
+              StructField("f", StringType)))))))))))))
     val q7 = vds.queryVA("va.a.b.c.f")._2
     assert(vds.variantsAndAnnotations
       .collect()
@@ -262,13 +262,13 @@ class AnnotationsSuite extends SparkSuite {
 
     assert(vds.vaSignature.schema ==
       StructType(Array(
-        StructField("0", toAdd3Sig.schema),
-        StructField("1", StringType),
-        StructField("2", StructType(Array(
-          StructField("0", StructType(Array(
-            StructField("0", StructType(Array(
-              StructField("0", StringType),
-              StructField("1", StringType)))))))))))))
+        StructField("I1", toAdd3Sig.schema),
+        StructField("S1", StringType),
+        StructField("a", StructType(Array(
+          StructField("b", StructType(Array(
+            StructField("c", StructType(Array(
+              StructField("d", StringType),
+              StructField("f", StringType)))))))))))))
 
     val q8 = vds.queryVA("va.a.b.c.d")._2
     assert(vds.variantsAndAnnotations
@@ -283,14 +283,14 @@ class AnnotationsSuite extends SparkSuite {
 
     assert(vds.vaSignature.schema ==
       StructType(Array(
-        StructField("0", toAdd3Sig.schema),
-        StructField("1", StringType),
-        StructField("2", StructType(Array(
-          StructField("0", StructType(Array(
-            StructField("0", StructType(Array(
-              StructField("0", StringType),
-              StructField("1", StringType))))))),
-          StructField("1", StringType)))))))
+        StructField("I1", toAdd3Sig.schema),
+        StructField("S1", StringType),
+        StructField("a", StructType(Array(
+          StructField("b", StructType(Array(
+            StructField("c", StructType(Array(
+              StructField("d", StringType),
+              StructField("f", StringType))))))),
+          StructField("c", StringType)))))))
     val q9 = vds.queryVA("va.a.c")._2
     assert(vds.variantsAndAnnotations
       .collect()
@@ -302,10 +302,10 @@ class AnnotationsSuite extends SparkSuite {
       .copy(vaSignature = s8)
     assert(vds.vaSignature.schema ==
       StructType(Array(
-        StructField("0", toAdd3Sig.schema),
-        StructField("1", StringType),
-        StructField("2", StructType(Array(
-          StructField("0", StringType)))))))
+        StructField("I1", toAdd3Sig.schema),
+        StructField("S1", StringType),
+        StructField("a", StructType(Array(
+          StructField("c", StringType)))))))
     val q10 = vds.queryVA("va.a")._2
     assert(vds.variantsAndAnnotations
       .collect()
@@ -318,8 +318,8 @@ class AnnotationsSuite extends SparkSuite {
 
     assert(vds.vaSignature.schema ==
       StructType(Array(
-        StructField("0", toAdd3Sig.schema),
-        StructField("1", StringType))))
+        StructField("I1", toAdd3Sig.schema),
+        StructField("S1", StringType))))
 
     assert(vds.variantsAndAnnotations
       .collect()
@@ -332,7 +332,7 @@ class AnnotationsSuite extends SparkSuite {
 
     assert(vds.vaSignature.schema ==
       StructType(Array(
-        StructField("0", StringType))))
+        StructField("S1", StringType))))
     assert(vds.variantsAndAnnotations
       .collect()
       .forall { case (v, va) => va == Annotation("test") })

--- a/src/test/scala/org/broadinstitute/hail/variant/KuduUtilsSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/KuduUtilsSuite.scala
@@ -1,0 +1,110 @@
+package org.broadinstitute.hail.variant
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.scalatest.testng.TestNGSuite
+import org.testng.annotations.Test
+
+class KuduUtilsSuite extends TestNGSuite {
+  @Test def testFlattenPrimitives() {
+    val schema = StructType(List(
+      StructField("f1", IntegerType), StructField("f2", StringType)))
+    assert(KuduUtils.flatten(schema) == schema)
+
+    val row = Row(1, "a")
+    roundTrip(schema, row, row)
+  }
+
+  @Test def testFlattenArray() {
+    val schema = StructType(List(StructField("f1", ArrayType(IntegerType))))
+    val flattenedSchema = StructType(List(
+      StructField("f1_0", IntegerType), StructField("f1_1", IntegerType)))
+    assert(KuduUtils.flatten(schema) == flattenedSchema)
+
+    roundTrip(schema, Row(List()), Row(null, null))
+    roundTrip(schema, Row(List(1)), Row(1, null))
+    roundTrip(schema, Row(List(1, 2)), Row(1, 2))
+    assert(KuduUtils.flatten(Row(List(1, 2, 3)), schema) == Row(1, 2))
+  }
+
+  @Test def testFlattenNested() {
+    val schema = StructType(List(
+      StructField("f1", StructType(List(StructField("s1", IntegerType))))))
+    val flattenedSchema = StructType(List(StructField("f1__s1", IntegerType)))
+    assert(KuduUtils.flatten(schema) == flattenedSchema)
+
+    roundTrip(schema, Row(Row(1)), Row(1))
+  }
+
+  @Test def testFlattenDeepNested() {
+    val schema = StructType(List(
+      StructField("f1", LongType),
+      StructField("f2", StructType(List(
+        StructField("s1", StructType(List(StructField("t1", IntegerType))))))),
+      StructField("f3", LongType)
+    ))
+    val flattenedSchema = StructType(List(
+      StructField("f1", LongType),
+      StructField("f2__s1__t1", IntegerType),
+      StructField("f3", LongType)))
+    assert(KuduUtils.flatten(schema) == flattenedSchema)
+
+    roundTrip(schema, Row(1L, Row(Row(2)), 3L), Row(1L, 2, 3L))
+  }
+
+  @Test def testFlattenArrayOfStruct() {
+    val schema = StructType(List(
+      StructField("f1", ArrayType(StructType(List(
+        StructField("s1", IntegerType),
+        StructField("s2", StringType)))))
+    ))
+    val flattenedSchema = StructType(List(
+      StructField("f1_0__s1", IntegerType),
+      StructField("f1_0__s2", StringType),
+      StructField("f1_1__s1", IntegerType),
+      StructField("f1_1__s2", StringType)))
+    assert(KuduUtils.flatten(schema) == flattenedSchema)
+
+    roundTrip(schema, Row(List(Row(1, "a"))), Row(1, "a", null, null))
+    roundTrip(schema, Row(List(Row(1, "a"), Row(2, "b"))), Row(1, "a", 2, "b"))
+  }
+
+  @Test def testFlattenComplex() {
+    val schema = StructType(List(
+      StructField("f1", ArrayType(LongType)),
+      StructField("f2", StructType(List(
+        StructField("s1", BooleanType),
+        StructField("s2", ByteType),
+        StructField("s3", ShortType),
+        StructField("s4", IntegerType),
+        StructField("s5", LongType),
+        StructField("s6", FloatType),
+        StructField("s7", DoubleType),
+        StructField("s8", StringType),
+        StructField("s9", BinaryType))))))
+    val flattenedSchema = StructType(List(
+      StructField("f1_0", LongType),
+      StructField("f1_1", LongType),
+      StructField("f2__s1", BooleanType),
+      StructField("f2__s2", ByteType),
+      StructField("f2__s3", ShortType),
+      StructField("f2__s4", IntegerType),
+      StructField("f2__s5", LongType),
+      StructField("f2__s6", FloatType),
+      StructField("f2__s7", DoubleType),
+      StructField("f2__s8", StringType),
+      StructField("f2__s9", BinaryType)))
+    assert(KuduUtils.flatten(schema) == flattenedSchema)
+
+    roundTrip(schema, Row(List(1L, 2L), Row(true, 3.toByte, 4.toShort, 5, 6L, 7.toFloat,
+      8.0, "a", Array(10.toByte, 11.toByte))),
+      Row(1L, 2L, true, 3.toByte, 4.toShort, 5, 6L, 7.toFloat, 8.0, "a",
+        Array(10.toByte, 11.toByte)))
+  }
+
+  def roundTrip(schema: StructType, row: Row, flattenedRow: Row): Unit = {
+    assert(KuduUtils.flatten(row, schema) == flattenedRow)
+    assert(KuduUtils.unflatten(flattenedRow, schema) == row)
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/hail/variant/KuduUtilsSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/KuduUtilsSuite.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.hail.variant
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
+import org.broadinstitute.hail.expr._
 import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.Test
 
@@ -9,7 +10,7 @@ class KuduUtilsSuite extends TestNGSuite {
   @Test def testFlattenPrimitives() {
     val schema = StructType(List(
       StructField("f1", IntegerType), StructField("f2", StringType)))
-    assert(KuduUtils.flatten(schema) == schema)
+    assert(KuduAnnotationImpex.flatten(schema) == schema)
 
     val row = Row(1, "a")
     roundTrip(schema, row, row)
@@ -19,19 +20,20 @@ class KuduUtilsSuite extends TestNGSuite {
     val schema = StructType(List(StructField("f1", ArrayType(IntegerType))))
     val flattenedSchema = StructType(List(
       StructField("f1_0", IntegerType), StructField("f1_1", IntegerType)))
-    assert(KuduUtils.flatten(schema) == flattenedSchema)
+    assert(KuduAnnotationImpex.flatten(schema) == flattenedSchema)
 
     roundTrip(schema, Row(List()), Row(null, null))
     roundTrip(schema, Row(List(1)), Row(1, null))
     roundTrip(schema, Row(List(1, 2)), Row(1, 2))
-    assert(KuduUtils.flatten(Row(List(1, 2, 3)), schema) == Row(1, 2))
+    assert(KuduAnnotationImpex.flatten(Row(List(1, 2, 3)),
+      SparkAnnotationImpex.importType(schema)) == Row(1, 2))
   }
 
   @Test def testFlattenNested() {
     val schema = StructType(List(
       StructField("f1", StructType(List(StructField("s1", IntegerType))))))
     val flattenedSchema = StructType(List(StructField("f1__s1", IntegerType)))
-    assert(KuduUtils.flatten(schema) == flattenedSchema)
+    assert(KuduAnnotationImpex.flatten(schema) == flattenedSchema)
 
     roundTrip(schema, Row(Row(1)), Row(1))
   }
@@ -47,7 +49,7 @@ class KuduUtilsSuite extends TestNGSuite {
       StructField("f1", LongType),
       StructField("f2__s1__t1", IntegerType),
       StructField("f3", LongType)))
-    assert(KuduUtils.flatten(schema) == flattenedSchema)
+    assert(KuduAnnotationImpex.flatten(schema) == flattenedSchema)
 
     roundTrip(schema, Row(1L, Row(Row(2)), 3L), Row(1L, 2, 3L))
   }
@@ -63,7 +65,7 @@ class KuduUtilsSuite extends TestNGSuite {
       StructField("f1_0__s2", StringType),
       StructField("f1_1__s1", IntegerType),
       StructField("f1_1__s2", StringType)))
-    assert(KuduUtils.flatten(schema) == flattenedSchema)
+    assert(KuduAnnotationImpex.flatten(schema) == flattenedSchema)
 
     roundTrip(schema, Row(List(Row(1, "a"))), Row(1, "a", null, null))
     roundTrip(schema, Row(List(Row(1, "a"), Row(2, "b"))), Row(1, "a", 2, "b"))
@@ -74,8 +76,8 @@ class KuduUtilsSuite extends TestNGSuite {
       StructField("f1", ArrayType(LongType)),
       StructField("f2", StructType(List(
         StructField("s1", BooleanType),
-        StructField("s2", ByteType),
-        StructField("s3", ShortType),
+        // StructField("s2", ByteType),
+        // StructField("s3", ShortType),
         StructField("s4", IntegerType),
         StructField("s5", LongType),
         StructField("s6", FloatType),
@@ -86,25 +88,29 @@ class KuduUtilsSuite extends TestNGSuite {
       StructField("f1_0", LongType),
       StructField("f1_1", LongType),
       StructField("f2__s1", BooleanType),
-      StructField("f2__s2", ByteType),
-      StructField("f2__s3", ShortType),
+      // StructField("f2__s2", ByteType),
+      // StructField("f2__s3", ShortType),
       StructField("f2__s4", IntegerType),
       StructField("f2__s5", LongType),
       StructField("f2__s6", FloatType),
       StructField("f2__s7", DoubleType),
       StructField("f2__s8", StringType),
       StructField("f2__s9", BinaryType)))
-    assert(KuduUtils.flatten(schema) == flattenedSchema)
+    assert(KuduAnnotationImpex.flatten(schema) == flattenedSchema)
 
-    roundTrip(schema, Row(List(1L, 2L), Row(true, 3.toByte, 4.toShort, 5, 6L, 7.toFloat,
+    roundTrip(schema, Row(List(1L, 2L), Row(true,
+      // 3.toByte, 4.toShort,
+      5, 6L, 7.toFloat,
       8.0, "a", Array(10.toByte, 11.toByte))),
-      Row(1L, 2L, true, 3.toByte, 4.toShort, 5, 6L, 7.toFloat, 8.0, "a",
+      Row(1L, 2L, true,
+        // 3.toByte, 4.toShort,
+        5, 6L, 7.toFloat, 8.0, "a",
         Array(10.toByte, 11.toByte)))
   }
 
   def roundTrip(schema: StructType, row: Row, flattenedRow: Row): Unit = {
-    assert(KuduUtils.flatten(row, schema) == flattenedRow)
-    assert(KuduUtils.unflatten(flattenedRow, schema) == row)
+    assert(KuduAnnotationImpex.flatten(row, SparkAnnotationImpex.importType(schema)) == flattenedRow)
+    assert(KuduAnnotationImpex.unflatten(flattenedRow, SparkAnnotationImpex.importType(schema)) == row)
   }
 
 }


### PR DESCRIPTION
This change allows variant annotations to be stored in Kudu. Since Kudu doesn't support nested or complex types, rows are flattened before writing, and then unflattened when read back.