### PR TITLE
Improvements to Solr and Cassandra export.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     compile 'org.json4s:json4s-jackson_2.10:3.2.10'
     compile 'org.json4s:json4s-ast_2.10:3.2.10'
 
-    compile 'org.apache.solr:solr-solrj:5.5.0'
+    compile 'org.apache.solr:solr-solrj:6.0.1'
     compile 'com.datastax.cassandra:cassandra-driver-core:3.0.0'
 
     testCompile 'org.testng:testng:6.8.21'
@@ -115,8 +115,9 @@ tasks.withType(ShadowJar) {
     baseName = project.name + '-all'
     mergeServiceFiles()
     zip64 true
-    // conflict with version of math3 in default Hadoop/Spark install
+    // conflict with version in default Hadoop/Spark install
     relocate 'org.apache.commons.math3', 'org.broadinstitute.hail.relocated.org.apache.commons.math3'
+    relocate 'org.apache.http', 'org.broadinstitute.hail.relocated.org.apache.http'
 }
 
 shadowJar {
@@ -136,7 +137,16 @@ shadowJar {
         include(dependency('org.json4s:json4s-jackson_2.10:.*'))
         include(dependency('org.json4s:json4s-ast_2.10:.*'))
 
+        // solr dependencies
         include(dependency('org.apache.solr:solr-solrj:.*'))
+        include(dependency('org.apache.httpcomponents:httpclient:.*'))
+        include(dependency('org.apache.httpcomponents:httpcore:.*'))
+        include(dependency('org.apache.httpcomponents:httpmime:.*'))
+        include(dependency('org.apache.zookeeper:zookeeper:.*'))
+        include(dependency('org.codehaus.woodstox:stax2-api:.*'))
+        include(dependency('org.codehaus.woodstox:woodstox-core-asl:.*'))
+        include(dependency('org.noggit:noggit:.*'))
+
         include(dependency('com.datastax.cassandra:cassandra-driver-core:.*'))
         include(dependency('org.kududb:kudu-client:.*'))
         include(dependency('org.kududb:kudu-spark_2.10:.*'))
@@ -160,7 +170,20 @@ task shadowTestJar(type: ShadowJar) {
         include(dependency('org.json4s:json4s-jackson_2.10:.*'))
         include(dependency('org.json4s:json4s-ast_2.10:.*'))
 
+        include(dependency('org.testng:testng:.*'))
+        include(dependency('com.beust:jcommander:.*'))
+        include(dependency('org.scalatest:scalatest_' + scalaMajorVersion + ':.*'))
+
+        // solr dependencies
         include(dependency('org.apache.solr:solr-solrj:.*'))
+        include(dependency('org.apache.httpcomponents:httpclient:.*'))
+        include(dependency('org.apache.httpcomponents:httpcore:.*'))
+        include(dependency('org.apache.httpcomponents:httpmime:.*'))
+        include(dependency('org.apache.zookeeper:zookeeper:.*'))
+        include(dependency('org.codehaus.woodstox:stax2-api:.*'))
+        include(dependency('org.codehaus.woodstox:woodstox-core-asl:.*'))
+        include(dependency('org.noggit:noggit:.*'))
+
         include(dependency('com.datastax.cassandra:cassandra-driver-core:.*'))
         include(dependency('org.kududb:kudu-client:.*'))
         include(dependency('org.kududb:kudu-spark_2.10:.*'))
@@ -189,7 +212,3 @@ task testJar(type: Jar) {
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
-
-compileScala {
-    scalaCompileOptions.useAnt = false
-}

--- a/src/main/scala/org/broadinstitute/hail/driver/ExportVariantsCass.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportVariantsCass.scala
@@ -1,14 +1,15 @@
 package org.broadinstitute.hail.driver
 
-import com.datastax.driver.core.{BoundStatement, Cluster, Session}
-import org.broadinstitute.hail.Utils._
+import com.datastax.driver.core._
+import com.datastax.driver.core.querybuilder.QueryBuilder
 import org.broadinstitute.hail.expr._
-import org.broadinstitute.hail.methods._
+import org.broadinstitute.hail.Utils._
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
-import scala.io.Source
+import scala.collection.JavaConverters._
+
+// FIXME add drop/create table option
 
 object CassandraStuff {
   private var cluster: Cluster = null
@@ -32,7 +33,7 @@ object CassandraStuff {
     session
   }
 
-  def releaseSession() {
+  def disconnect() {
     this.synchronized {
       refcount -= 1
       if (refcount == 0) {
@@ -50,17 +51,25 @@ object ExportVariantsCass extends Command {
 
   class Options extends BaseOptions {
 
-    @Args4jOption(required = true, name = "-c", aliases = Array("--condition"),
-      usage = "comma-separated list of fields/computations to be exported")
-    var condition: String = _
-
     @Args4jOption(required = true, name = "-a", aliases = Array("--address"),
       usage = "Cassandra contact point to connect to")
     var address: String = _
 
+    @Args4jOption(required = true, name = "-g",
+      usage = "comma-separated list of fields/computations to be exported")
+    var genotypeCondition: String = _
+
+    @Args4jOption(required = true, name = "-k",
+      usage = "Cassandra keyspace")
+    var keyspace: String = _
+
     @Args4jOption(required = true, name = "-t", aliases = Array("--table"),
-      usage = "Cassandra table to export to")
+      usage = "Cassandra table")
     var table: String = _
+
+    @Args4jOption(required = true, name = "-v",
+      usage = "comma-separated list of fields/computations to be exported")
+    var variantCondition: String = _
 
   }
 
@@ -74,10 +83,80 @@ object ExportVariantsCass extends Command {
 
   def requiresVDS = true
 
+  def toCassType(t: Type): String = t match {
+    case TBoolean => "boolean"
+    case TInt => "int"
+    case TLong => "bigint"
+    case TFloat => "float"
+    case TDouble => "double"
+    case TString => "text"
+    case TArray(elementType) =>
+      s"list<${toCassType(elementType)}>"
+    case _ =>
+      // FIXME
+      fatal("")
+  }
+
+  def toCassValue(a: Any, t: Type): AnyRef = t match {
+    case TArray(elementType) => a.asInstanceOf[Seq[_]].asJava
+    case _ => a.asInstanceOf[AnyRef]
+  }
+
+  def escapeCassColumnName(name: String): String = {
+    val sb = new StringBuilder
+
+    if (name.head.isDigit)
+      sb += 'x'
+
+    name.foreach { c =>
+      if (c.isLetterOrDigit)
+        sb += c.toLower
+      else
+        sb += '_'
+    }
+
+    sb.result()
+  }
+
   def run(state: State, options: Options): State = {
     val vds = state.vds
+    val sc = vds.sparkContext
     val vas = vds.vaSignature
-    val cond = options.condition
+    val sas = vds.saSignature
+    val gCond = options.genotypeCondition
+    val vCond = options.variantCondition
+    val address = options.address
+
+    val keyspace = options.keyspace
+    val table = options.table
+    val qualifiedTable = keyspace + "." + table
+
+    val vSymTab = Map(
+      "v" ->(0, TVariant),
+      "va" ->(1, vas))
+    val vEC = EvalContext(vSymTab)
+    val vA = vEC.a
+
+    val vparsed = Parser.parseAnnotationArgs(vCond, vEC)
+      .map { case (name, t, f) =>
+        assert(name.tail == Nil)
+        (name.head, t, f)
+      }
+
+    val gSymTab = Map(
+      "v" ->(0, TVariant),
+      "va" ->(1, vas),
+      "s" ->(2, TSample),
+      "sa" ->(3, sas),
+      "g" ->(4, TGenotype))
+    val gEC = EvalContext(gSymTab)
+    val gA = gEC.a
+
+    val gparsed = Parser.parseAnnotationArgs(gCond, gEC)
+      .map { case (name, t, f) =>
+        assert(name.tail == Nil)
+        (name.head, t, f)
+      }
 
     val symTab = Map(
       "v" ->(0, TVariant),
@@ -85,48 +164,78 @@ object ExportVariantsCass extends Command {
     val ec = EvalContext(symTab)
     val a = ec.a
 
-    val (header, fs) = Parser.parseNamedArgs(cond, ec)
-    if (header.isEmpty)
-      fatal("column names required in condition")
+    val fields = (vparsed.map { case (name, t, f) => (escapeCassColumnName(name), t) }
+      ++ vds.sampleIds.flatMap { s =>
+      gparsed.map { case (name, t, f) => (escapeCassColumnName(s + "_" + name), t) }
+    })
 
-    val address = options.address
+    val session = CassandraStuff.getSession(address)
 
-    val query =
-      s"""
-         |INSERT INTO ${options.table}
-         |(chrom, pos, ref, alt, ${header.mkString(", ")})
-         |VALUES (?, ?, ?, ?, ${header.map(_ => "?").mkString(", ")});
-      """.stripMargin
+    // FIXME check keyspace, table exsit (null)
+    val tableMetadata = session.getCluster.getMetadata.getKeyspace(keyspace).getTable(table)
+    val preexistingFields = tableMetadata.getColumns.asScala.map(_.getName).toSet
+    val toAdd = fields
+      .filter { case (name, t) => !preexistingFields(name) }
 
-    vds.variantsAndAnnotations
+    if (toAdd.nonEmpty) {
+      session.execute(s"ALTER TABLE $qualifiedTable ADD (${
+        toAdd.map { case (name, t) => s"$name ${toCassType(t)}" }.mkString(",")
+      })")
+    }
+
+    CassandraStuff.disconnect()
+
+    val sampleIdsBc = sc.broadcast(vds.sampleIds)
+    val sampleAnnotationsBc = sc.broadcast(vds.sampleAnnotations)
+
+    val futures = vds.rdd
       .foreachPartition { it =>
         val session = CassandraStuff.getSession(address)
 
-        val statement = session.prepare(query)
-        val ab = mutable.ArrayBuilder.make[AnyRef]
+        val nb = mutable.ArrayBuilder.make[String]
+        val vb = mutable.ArrayBuilder.make[AnyRef]
 
-        val futures = it.map { case (v, va) =>
-          ab.clear()
-          ab += v.contig
-          ab += v.start.asInstanceOf[AnyRef]
-          ab += v.ref
-          ab += v.alt
-          fs.foreach { f =>
-            a(0) = v
-            a(1) = va
-            ab += f().asInstanceOf[AnyRef]
+        val futures = it
+          .map { case (v, va, gs) =>
+            nb.clear()
+            vb.clear()
+
+            vparsed.foreach { case (name, t, f) =>
+              vEC.setAll(v, va)
+              f().foreach { a =>
+                nb += escapeCassColumnName(name)
+                vb += toCassValue(a, t)
+              }
+            }
+
+            gs.iterator.zipWithIndex.foreach { case (g, i) =>
+              val s = sampleIdsBc.value(i)
+              val sa = sampleAnnotationsBc.value(i)
+              gparsed.foreach { case (name, t, f) =>
+                if (g.isCalled && !g.isHomRef) {
+                  gEC.setAll(v, va, s, sa, g)
+                  f().foreach { a =>
+                    nb += escapeCassColumnName(s + "_" + name)
+                    vb += toCassValue(a, t)
+                  }
+                }
+              }
+            }
+
+            val names = nb.result()
+            val values = vb.result()
+
+            session.executeAsync(QueryBuilder
+              .insertInto(keyspace, table)
+              .values(names, values))
           }
-          val r = ab.result()
-          val boundStatement = new BoundStatement(statement)
-
-          session.executeAsync(boundStatement.bind(r: _*))
-        }
 
         futures.foreach(_.getUninterruptibly())
 
-        CassandraStuff.releaseSession()
+        CassandraStuff.disconnect()
       }
 
     state
   }
+
 }

--- a/src/main/scala/org/broadinstitute/hail/driver/ExportVariantsSolr.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/ExportVariantsSolr.scala
@@ -1,25 +1,39 @@
 package org.broadinstitute.hail.driver
 
-import org.apache.solr.client.solrj.impl.HttpSolrClient
-import org.apache.solr.common.SolrInputDocument
-import org.broadinstitute.hail.expr.{EvalContext, Parser, TArray, TVariant}
+import org.apache.solr.client.solrj.impl.{CloudSolrClient, HttpSolrClient}
+import org.apache.solr.client.solrj.request.schema.SchemaRequest
+import org.apache.solr.common.{SolrException, SolrInputDocument}
+import org.broadinstitute.hail.expr._
 
 import scala.collection.JavaConverters._
 import org.broadinstitute.hail.Utils._
 import org.kohsuke.args4j.{Option => Args4jOption}
 
 import scala.collection.mutable
+import scala.util.Random
 
-object ExportVariantsSolr extends Command {
+object ExportVariantsSolr extends Command with Serializable {
 
   class Options extends BaseOptions {
-    @Args4jOption(required = true, name = "-c", aliases = Array("--condition"),
-      usage = "comma-separated list of fields/computations to be exported")
-    var condition: String = _
+    @Args4jOption(name = "-c",
+      usage = "SolrCloud collection")
+    var collection: String = _
 
-    @Args4jOption(required = true, name = "-u", aliases = Array("--url"),
+    @Args4jOption(required = true, name = "-g",
+      usage = "comma-separated list of fields/computations to be exported")
+    var genotypeCondition: String = _
+
+    @Args4jOption(name = "-u", aliases = Array("--url"),
       usage = "Solr instance (URL) to connect to")
     var url: String = _
+
+    @Args4jOption(required = true, name = "-v",
+      usage = "comma-separated list of fields/computations to be exported")
+    var variantCondition: String = _
+
+    @Args4jOption(name = "-z", aliases = Array("--zk-host"),
+      usage = "Zookeeper host string to connect to")
+    var zkHost: String = _
 
   }
 
@@ -33,66 +47,197 @@ object ExportVariantsSolr extends Command {
 
   def requiresVDS = true
 
+  def toSolrType(t: Type): String = t match {
+    case TInt => "tint"
+    case TLong => "tlong"
+    case TFloat => "tfloat"
+    case TDouble => "tdouble"
+    case TBoolean => "boolean"
+    case TString => "string"
+    // FIXME only 1 deep
+    case i: TIterable => toSolrType(i.elementType)
+      // FIXME
+    case _ => fatal("")
+  }
+
+  def escapeSolrFieldName(name: String): String = {
+    val sb = new StringBuilder
+
+    if (name.head.isDigit)
+      sb += '_'
+
+    name.foreach { c =>
+      if (c.isLetterOrDigit)
+        sb += c
+      else
+        sb += '_'
+    }
+
+    sb.result()
+  }
+
+  def addFieldReq(preexistingFields: Set[String], name: String, t: Type): Option[SchemaRequest.AddField] = {
+    val escapedName = escapeSolrFieldName(name)
+    if (preexistingFields(escapedName))
+      return None
+
+    val m = mutable.Map.empty[String, AnyRef]
+
+    // FIXME check type
+
+    m += "name" -> escapedName
+    m += "type" -> toSolrType(t)
+    m += "stored" -> true.asInstanceOf[AnyRef]
+    if (t.isInstanceOf[TIterable])
+      m += "multiValued" -> true.asInstanceOf[AnyRef]
+
+    val req = new SchemaRequest.AddField(m.asJava)
+    Some(req)
+  }
+
+  def documentAddField(document: SolrInputDocument, name: String, t: Type, value: Any) {
+    if (t.isInstanceOf[TIterable]) {
+      value.asInstanceOf[Seq[_]].foreach { xi =>
+        document.addField(escapeSolrFieldName(name), xi)
+      }
+    } else
+      document.addField(escapeSolrFieldName(name), value)
+  }
+
   def run(state: State, options: Options): State = {
     val sc = state.vds.sparkContext
     val vds = state.vds
     val vas = vds.vaSignature
-    val cond = options.condition
+    val sas = vds.saSignature
+    val gCond = options.genotypeCondition
+    val vCond = options.variantCondition
+    val collection = options.collection
 
-    val symTab = Map(
+    val vSymTab = Map(
       "v" ->(0, TVariant),
       "va" ->(1, vas))
-    val ec = EvalContext(symTab)
-    val a = ec.a
+    val vEC = EvalContext(vSymTab)
+    val vA = vEC.a
 
-    val (header, fs) = Parser.parseNamedArgs(cond, ec)
-    if (header.isEmpty)
-      fatal("column names required in condition")
+    // FIXME use custom parser with constraint on Solr field name
+    val vparsed = Parser.parseAnnotationArgs(vCond, vEC)
+      .map { case (name, t, f) =>
+        assert(name.tail == Nil)
+        (name.head, t, f)
+      }
+
+    val gSymTab = Map(
+      "v" ->(0, TVariant),
+      "va" ->(1, vas),
+      "s" ->(2, TSample),
+      "sa" ->(3, sas),
+      "g" ->(4, TGenotype))
+    val gEC = EvalContext(gSymTab)
+    val gA = gEC.a
+
+    val gparsed = Parser.parseAnnotationArgs(gCond, gEC)
+      .map { case (name, t, f) =>
+        assert(name.tail == Nil)
+        (name.head, t, f)
+      }
 
     val url = options.url
+    val zkHost = options.zkHost
+
+    if (url == null && zkHost == null)
+      fatal("one of -u or -z required")
+
+    if (url != null && zkHost != null)
+      fatal("both -u and -z given")
+
+    if (zkHost != null && collection == null)
+      fatal("-c required with -z")
+
+    val solr =
+      if (url != null)
+        new HttpSolrClient(url)
+      else {
+        val cc = new CloudSolrClient(zkHost)
+        cc.setDefaultCollection(collection)
+        cc
+      }
+
+    // retrieve current fields
+    val fieldsResponse = new SchemaRequest.Fields().process(solr)
+
+    val preexistingFields = fieldsResponse.getFields.asScala
+      .map(_.asScala("name").asInstanceOf[String])
+      .toSet
+
+    val addFieldReqs = vparsed.flatMap { case (name, t, f) =>
+      addFieldReq(preexistingFields, name, t)
+    } ++ vds.sampleIds.flatMap { s =>
+      gparsed.flatMap { case (name, t, f) =>
+        addFieldReq(preexistingFields, s + "_" + name, t)
+      }
+    }
+
+    info(s"adding ${addFieldReqs.length} fields")
+
+    if (addFieldReqs.nonEmpty) {
+      val req = new SchemaRequest.MultiUpdate((addFieldReqs.toList: List[SchemaRequest.Update]).asJava)
+      req.process(solr)
+    }
 
     val sampleIdsBc = sc.broadcast(vds.sampleIds)
+    val sampleAnnotationsBc = sc.broadcast(vds.sampleAnnotations)
+
     vds.rdd.foreachPartition { it =>
       val ab = mutable.ArrayBuilder.make[AnyRef]
       val documents = it.map { case (v, va, gs) =>
 
         val document = new SolrInputDocument()
 
-        /*
-        document.addField("chr", v.contig)
-        document.addField("pos", v.start)
-        document.addField("ref", v.ref)
-        document.addField("pos", v.alt) */
-
-        fs.zip(header).foreach { case (f, col) =>
-          a(0) = v
-          a(1) = va
-          document.addField(col, f().asInstanceOf[AnyRef])
+        vparsed.foreach { case (name, t, f) =>
+          vEC.setAll(v, va)
+          f().foreach(x => documentAddField(document, name, t, x))
         }
-
-        gs.iterator.zip(sampleIdsBc.value.iterator).foreach { case (g, id) =>
-          g.nNonRefAlleles
-            .filter(_ > 0)
-            .foreach { n =>
-              document.addField(id + "_num_alt", n.toString)
-              g.ad.foreach { ada =>
-                val ab = ada(0).toDouble / (ada(0) + ada(1))
-                document.addField(id + "_ab", ab.toString)
-              }
-              g.gq.foreach { gqx =>
-                document.addField(id + "_gq", gqx.toString)
-              }
+        
+        gs.iterator.zipWithIndex.foreach { case (g, i) =>
+          if (g.isCalled && !g.isHomRef) {
+            val s = sampleIdsBc.value(i)
+            val sa = sampleAnnotationsBc.value(i)
+            gparsed.foreach { case (name, t, f) =>
+              gEC.setAll(v, va, s, sa, g)
+              f().foreach(x => documentAddField(document, s + "_" + name, t, x))
             }
+          }
         }
 
         document
       }
 
-      val solr = new HttpSolrClient(url)
-      solr.add(documents.asJava)
+      val solr =
+        if (url != null)
+          new HttpSolrClient(url)
+        else {
+          val cc = new CloudSolrClient(zkHost)
+          cc.setDefaultCollection(collection)
+          cc
+        }
 
-      // FIXME back off it commit fails
-      solr.commit()
+      var retry = true
+      var retryInterval = 3 * 1000 // 3s
+      val maxRetryInterval = 3 * 60 * 1000 // 3m
+
+      while (retry) {
+        try {
+          solr.add(documents.asJava)
+          solr.commit()
+          retry = false
+        } catch {
+          case e: SolrException =>
+            warn("add documents timeout, retrying")
+
+            Thread.sleep(Random.nextInt(retryInterval))
+            retryInterval = (retryInterval * 2).max(maxRetryInterval)
+        }
+      }
     }
 
     state


### PR DESCRIPTION
Customize export variant- and genotype-level fields.
Upgrade to SorlJ 6, add dependencies.
Support SolrCloud.
Retry on Solr error.
Only insert non-null fields.
Only export called non-ref genotypes.