### PR TITLE
added inParXPos and inParYPos

### DIFF
--- a/docs/Representation.md
+++ b/docs/Representation.md
@@ -63,8 +63,10 @@ Identifier | Type | Description
 `v.nAltAlleles`         | `Int`       | number of alternate alleles, equal to `nAlleles - 1`
 `v.nGenotypes`          | `Int`       | number of genotypes
 `v.altAlleles`  | `Array[AltAllele]`  | the alternate alleles
-`v.inParX`              |  `Boolean`  | true if in pseudo-autosomal region on chromosome X
-`v.inParY`              |  `Boolean`  | true if in pseudo-autosomal region on chromosome Y
+`v.inXPar`              |  `Boolean`  | true if chromosome is X and start is in pseudo-autosomal region of X
+`v.inYPar`              |  `Boolean`  | true if chromosome is Y and start is in pseudo-autosomal region of Y. _NB: most callers assign variants in PAR to X_
+`v.inXNonPar`           |  `Boolean`  | true if chromosome is X and start is not in pseudo-autosomal region of X
+`v.inYNonPar`           |  `Boolean`  | true if chromosome is Y and start is not in pseudo-autosomal region of Y
 `v.altAllele`           | `AltAllele` | The alternate allele (schema below).  **Assumes biallelic.**
 `v.alt`                 | `String`    | Alternate allele sequence.  **Assumes biallelic.**
 

--- a/src/main/scala/org/broadinstitute/hail/expr/AST.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/AST.scala
@@ -245,8 +245,11 @@ case class Select(posn: Position, lhs: AST, rhs: String) extends AST(posn, lhs) 
       case (TVariant, "nAlleles") => TInt
       case (TVariant, "isBiallelic") => TBoolean
       case (TVariant, "nGenotypes") => TInt
-      case (TVariant, "inParX") => TBoolean
-      case (TVariant, "inParY") => TBoolean
+      case (TVariant, "inXPar") => TBoolean
+      case (TVariant, "inYPar") => TBoolean
+      case (TVariant, "inXNonPar") => TBoolean
+      case (TVariant, "inYNonPar") => TBoolean
+
       // assumes biallelic
       case (TVariant, "alt") => TString
       case (TVariant, "altAllele") => TAltAllele
@@ -353,10 +356,14 @@ case class Select(posn: Position, lhs: AST, rhs: String) extends AST(posn, lhs) 
       AST.evalCompose[Variant](ec, lhs)(_.isBiallelic)
     case (TVariant, "nGenotypes") =>
       AST.evalCompose[Variant](ec, lhs)(_.nGenotypes)
-    case (TVariant, "inParX") =>
-      AST.evalCompose[Variant](ec, lhs)(_.inParX)
-    case (TVariant, "inParY") =>
-      AST.evalCompose[Variant](ec, lhs)(_.inParY)
+    case (TVariant, "inXPar") =>
+      AST.evalCompose[Variant](ec, lhs)(_.inXPar)
+    case (TVariant, "inYPar") =>
+      AST.evalCompose[Variant](ec, lhs)(_.inYPar)
+    case (TVariant, "inXNonPar") =>
+      AST.evalCompose[Variant](ec, lhs)(_.inXNonPar)
+    case (TVariant, "inYNonPar") =>
+      AST.evalCompose[Variant](ec, lhs)(_.inYNonPar)
     // assumes biallelic
     case (TVariant, "alt") =>
       AST.evalCompose[Variant](ec, lhs)(_.alt)

--- a/src/main/scala/org/broadinstitute/hail/methods/ImputeSexPlink.scala
+++ b/src/main/scala/org/broadinstitute/hail/methods/ImputeSexPlink.scala
@@ -42,9 +42,9 @@ object ImputeSexPlink {
 
     vds.filterVariants((v: Variant, va: Annotation, gs: Iterable[Genotype]) =>
       if (!includePar)
-        (v.contig == "X" || v.contig == "23") && !v.inParX
+        v.inXNonPar
       else
-        v.contig == "X" || v.contig == "23"
+        v.contig == "X" || v.contig == "23" || v.contig == "25"
     )
       .mapAnnotations((v: Variant, va: Annotation, gs: Iterable[Genotype]) =>
         query.map(_.apply(va).orNull)

--- a/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
@@ -233,17 +233,23 @@ case class Variant(contig: String,
 
   // PAR regions of sex chromosomes: https://en.wikipedia.org/wiki/Pseudoautosomal_region
   // Boundaries for build GRCh37: http://www.ncbi.nlm.nih.gov/projects/genome/assembly/grc/human/
-  def inParX: Boolean = (60001 <= start && start <= 2699520) || (154931044 <= start && start <= 155260560)
+  def inXParPos: Boolean = (60001 <= start && start <= 2699520) || (154931044 <= start && start <= 155260560)
+  def inYParPos: Boolean = (10001 <= start && start <= 2649520) || (59034050 <= start && start <= 59363566)
 
-  def inParY: Boolean = (10001 <= start && start <= 2649520) || (59034050 <= start && start <= 59363566)
+  // FIXME: will replace with contig == "X" etc once bgen/plink support is merged and conversion is handled by import
+  def inXPar: Boolean = (contig == "X" || contig == "23" || contig == "25") && inXParPos
+  def inYPar: Boolean = (contig == "Y" || contig == "24") && inYParPos
+
+  def inXNonPar: Boolean = (contig == "X" || contig == "23" || contig == "25") && !inXParPos
+  def inYNonPar: Boolean = (contig == "Y" || contig == "24") && !inYParPos
 
   import CopyState._
 
   def copyState(sex: Sex.Sex): CopyState =
     if (sex == Sex.Male)
-      if (contig == "X" && !inParX)
+      if (inXNonPar)
         HemiX
-      else if (contig == "Y" && !inParY)
+      else if (inYNonPar)
         HemiY
       else
         Auto


### PR DESCRIPTION
this small PR addresses #452 

alternatively, we could only have inParX and inParY, but this introduces redundant contig checks in two of three usages.