### PR TITLE
teach VSM generator to work linearly on size

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/expr/Type.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/Type.scala
@@ -647,10 +647,10 @@ case class TStruct(fields: IndexedSeq[Field]) extends Type {
 
   override def genValue: Gen[Annotation] = {
     if (size == 0)
-      Gen.const[Annotation](Annotation.empty)
+      Gen.const(Annotation.empty)
     else
-      Gen.sequence[IndexedSeq[Annotation], Annotation](
-        fields.map(f => f.`type`.genValue))
-        .map(a => Annotation(a: _*))
+      Gen.getSize.flatMap(fuel =>
+        if (size < fuel) Gen.const(Annotation.empty)
+        else Gen.uniformSequence(fields.map(f => f.`type`.genValue)).map(a => Annotation(a: _*)))
   }
 }


### PR DESCRIPTION
Resolves broadinstitute/hail#535 by choosing uniformly(?) a partition of the given size.

The partition algorithm is [defined in Gen](https://github.com/danking/hail/blob/4dcde7e15c0cb9de402e0a2307f7f8e8a56054bd/src/main/scala/org/broadinstitute/hail/check/Gen.scala#L23-L34). It takes `size` balls and randomly places each one in a bin. The algorithm @jbloom22 described to me last night would draw O(partition) random numbers.

This approximately halved the run-time of `grade test` on my machine.