### PR TITLE
add: Gen builders have higher kinded types

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/Utils.scala
+++ b/src/main/scala/org/broadinstitute/hail/Utils.scala
@@ -1279,7 +1279,7 @@ object Utils extends Logging {
   def genBase: Gen[Char] = Gen.oneOf('A', 'C', 'T', 'G')
 
   // ignore size; atomic, like String
-  def genDNAString: Gen[String] = Gen.buildableOf[String, Char](genBase)
+  def genDNAString: Gen[String] = Gen.stringOf(genBase)
     .resize(12)
     .filter(s => !s.isEmpty)
 

--- a/src/main/scala/org/broadinstitute/hail/check/Arbitrary.scala
+++ b/src/main/scala/org/broadinstitute/hail/check/Arbitrary.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.hail.check
 
 import scala.collection.generic.CanBuildFrom
 import scala.math.Numeric.Implicits._
+import scala.language.higherKinds
 
 object Arbitrary {
   def apply[T](arbitrary: Gen[T]): Arbitrary[T] =
@@ -36,8 +37,8 @@ object Arbitrary {
     b.result()
   })))
 
-  implicit def arbBuildableOf[C, T](implicit a: Arbitrary[T], cbf: CanBuildFrom[Nothing, T, C]): Arbitrary[C] =
-    Arbitrary(Gen.buildableOf[C, T](a.arbitrary))
+  implicit def arbBuildableOf[C[_], T](implicit a: Arbitrary[T], cbf: CanBuildFrom[Nothing, T, C[T]]): Arbitrary[C[T]] =
+    Arbitrary(Gen.buildableOf(a.arbitrary))
 
   def arbitrary[T](implicit arb: Arbitrary[T]): Gen[T] = arb.arbitrary
 }

--- a/src/main/scala/org/broadinstitute/hail/check/Gen.scala
+++ b/src/main/scala/org/broadinstitute/hail/check/Gen.scala
@@ -5,6 +5,7 @@ import org.apache.commons.math3.random._
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable
 import scala.math.Numeric.Implicits._
+import scala.language.higherKinds
 
 object Parameters {
   val default = Parameters(new RandomDataGenerator(), 100, 100)
@@ -120,7 +121,16 @@ object Gen {
       b.result()
     }
 
-  def buildableOf[C, T](g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, C]): Gen[C] =
+  def stringOf[T](g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, String]): Gen[String] =
+    unsafeBuildableOf(g)
+
+  def buildableOf[C[_], T](g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, C[T]]): Gen[C[T]] =
+    unsafeBuildableOf(g)
+
+  def buildableOf2[C[_,_], T, U](g: Gen[(T,U)])(implicit cbf: CanBuildFrom[Nothing, (T,U), C[T,U]]): Gen[C[T, U]] =
+    unsafeBuildableOf(g)
+
+  private def unsafeBuildableOf[C,T](g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, C]): Gen[C] =
     Gen { (p: Parameters) =>
       val b = cbf()
       if (p.size == 0)
@@ -134,7 +144,7 @@ object Gen {
       }
     }
 
-  def distinctBuildableOf[C, T](g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, C]): Gen[C] =
+  def distinctBuildableOf[C[_], T](g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, C[T]]): Gen[C[T]] =
     Gen { (p: Parameters) =>
       val b = cbf()
       if (p.size == 0)
@@ -150,7 +160,7 @@ object Gen {
       }
     }
 
-  def buildableOfN[C, T](n: Int, g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, C]): Gen[C] =
+  def buildableOfN[C[_], T](n: Int, g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, C[T]]): Gen[C[T]] =
     Gen { (p: Parameters) =>
       val part = partition(p.rng, p.size, n)
       val b = cbf()
@@ -159,7 +169,7 @@ object Gen {
       b.result()
     }
 
-  def distinctBuildableOfN[C, T](n: Int, g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, C]): Gen[C] =
+  def distinctBuildableOfN[C[_], T](n: Int, g: Gen[T])(implicit cbf: CanBuildFrom[Nothing, T, C[T]]): Gen[C[T]] =
     Gen { (p: Parameters) =>
       val part = partition(p.rng, p.size, n)
       val t: mutable.Set[T] = mutable.Set.empty[T]

--- a/src/main/scala/org/broadinstitute/hail/expr/Type.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/Type.scala
@@ -32,11 +32,11 @@ object Type {
         genArb.resize(size - 1).map(TArray),
         genArb.resize(size - 1).map(TSet),
         genArb.resize(size - 1).map(TDict),
-        Gen.buildableOf[Array[(String, Type, Map[String, String])], (String, Type, Map[String, String])](
+        Gen.buildableOf[Array, (String, Type, Map[String, String])](
           Gen.zip(Gen.identifier,
             genArb,
             Gen.option(
-              Gen.buildableOf[Map[String, String], (String, String)](
+              Gen.buildableOf2[Map, String, String](
                 Gen.zip(arbitrary[String].filter(s => !s.isEmpty), arbitrary[String])))
               .map(o => o.getOrElse(Map.empty[String, String]))))
           .filter(fields => fields.map(_._1).areDistinct())
@@ -129,7 +129,7 @@ case object TBinary extends Type {
 
   def typeCheck(a: Any): Boolean = a == null || a.isInstanceOf[Array[Byte]]
 
-  override def genValue: Gen[Annotation] = Gen.buildableOf[Array[Byte], Byte](arbitrary[Byte])
+  override def genValue: Gen[Annotation] = Gen.buildableOf(arbitrary[Byte])
 }
 
 case object TBoolean extends Type {
@@ -255,8 +255,7 @@ case class TArray(elementType: Type) extends TIterable {
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 
-  override def genValue: Gen[Annotation] = Gen.buildableOf[IndexedSeq[Annotation], Annotation](
-    elementType.genValue)
+  override def genValue: Gen[Annotation] = Gen.buildableOf[IndexedSeq, Annotation](elementType.genValue)
 }
 
 case class TSet(elementType: Type) extends TIterable {
@@ -273,8 +272,7 @@ case class TSet(elementType: Type) extends TIterable {
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 
-  override def genValue: Gen[Annotation] = Gen.buildableOf[Set[Annotation], Annotation](
-    elementType.genValue)
+  override def genValue: Gen[Annotation] = Gen.buildableOf[Set,Annotation](elementType.genValue)
 }
 
 case class TDict(elementType: Type) extends Type {
@@ -291,8 +289,8 @@ case class TDict(elementType: Type) extends Type {
 
   override def str(a: Annotation): String = JsonMethods.compact(toJSON(a))
 
-  override def genValue: Gen[Annotation] = Gen.buildableOf[Map[String, Annotation], (String, Annotation)](
-    Gen.zip(arbitrary[String], elementType.genValue))
+  override def genValue: Gen[Annotation] =
+    Gen.buildableOf2[Map, String, Annotation](Gen.zip(arbitrary[String], elementType.genValue))
 }
 
 case object TSample extends Type {

--- a/src/main/scala/org/broadinstitute/hail/methods/Pedigree.scala
+++ b/src/main/scala/org/broadinstitute/hail/methods/Pedigree.scala
@@ -117,7 +117,7 @@ object Pedigree {
   }
 
   def genWithIds(): Gen[(IndexedSeq[String], Pedigree)] = {
-    for (ids <- Gen.distinctBuildableOf[IndexedSeq[String], String](Gen.identifier);
+    for (ids <- Gen.distinctBuildableOf(Gen.identifier);
          ped <- gen(ids))
       yield (ids, ped)
   }

--- a/src/main/scala/org/broadinstitute/hail/utils/IntervalTree.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/IntervalTree.scala
@@ -69,8 +69,7 @@ object IntervalTree {
   }
 
   def gen[T: Ordering](tgen: Gen[T]): Gen[IntervalTree[T]] = {
-    Gen.buildableOf[Array[Interval[T]], Interval[T]](Interval.gen(tgen))
-      .map(intervals => IntervalTree(intervals))
+    Gen.buildableOf[Array, Interval[T]](Interval.gen(tgen)) map { IntervalTree(_) }
   }
 }
 

--- a/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
@@ -461,11 +461,11 @@ object Genotype {
   def gen(v: Variant): Gen[Genotype] = {
     val m = Int.MaxValue / (v.nAlleles + 1)
     for (gt: Option[Int] <- Gen.option(Gen.choose(0, v.nGenotypes - 1));
-      ad <- Gen.option(Gen.buildableOfN[Array[Int], Int](v.nAlleles,
+      ad <- Gen.option(Gen.buildableOfN[Array, Int](v.nAlleles,
         Gen.choose(0, m)));
       dp <- Gen.option(Gen.choose(0, m));
       gq <- Gen.option(Gen.choose(0, 10000));
-      pl <- Gen.option(Gen.buildableOfN[Array[Int], Int](v.nGenotypes,
+      pl <- Gen.option(Gen.buildableOfN[Array, Int](v.nGenotypes,
         Gen.choose(0, m)))) yield {
       gt.foreach { gtx =>
         pl.foreach { pla => pla(gtx) = 0 }
@@ -487,17 +487,17 @@ object Genotype {
 
   def genRealistic(v: Variant): Gen[Genotype] = {
     for (callRate <- Gen.choose(0d, 1d);
-      alleleFrequencies <- Gen.buildableOfN[Array[Double], Double](v.nAlleles, Gen.choose(1e-6, 1d))  // avoid divison by 0
+      alleleFrequencies <- Gen.buildableOfN[Array, Double](v.nAlleles, Gen.choose(1e-6, 1d))  // avoid divison by 0
         .map { rawWeights =>
           val sum = rawWeights.sum
           rawWeights.map(_ / sum)
         };
       gt <- Gen.option(Gen.zip(Gen.chooseWithWeights(alleleFrequencies), Gen.chooseWithWeights(alleleFrequencies))
         .map { case (gti, gtj) => gtIndexWithSwap(gti, gtj) }, callRate);
-      ad <- Gen.option(Gen.buildableOfN[Array[Int], Int](v.nAlleles,
+      ad <- Gen.option(Gen.buildableOfN[Array, Int](v.nAlleles,
         Gen.choose(0, 50)));
       dp <- Gen.choose(0, 30).map(d => ad.map(o => o.sum + d));
-      pl <- Gen.option(Gen.buildableOfN[Array[Int], Int](v.nGenotypes, Gen.choose(0, 1000)).map { arr =>
+      pl <- Gen.option(Gen.buildableOfN[Array, Int](v.nGenotypes, Gen.choose(0, 1000)).map { arr =>
         gt match {
           case Some(i) =>
             arr(i) = 0

--- a/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
@@ -193,7 +193,7 @@ case class VariantSubgen(
       start <- startGen;
       nAlleles <- nAllelesGen;
       ref <- refGen;
-      altAlleles <- Gen.distinctBuildableOfN[Array[String], String](
+      altAlleles <- Gen.distinctBuildableOfN[Array, String](
         nAlleles,
         altGen)
         .filter(!_.contains(ref))) yield

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -225,17 +225,17 @@ case class VSMSubgen[T](
          sampleIds <- sampleIdGen;
          global <- globalGen(globalSig);
          saValues <- saGen(sampleIds.length, saSig);
-         rows <- Gen.distinctBuildableOf[Seq[(Variant, (Annotation, Iterable[T]))], (Variant, (Annotation, Iterable[T]))](
+         rows <- Gen.distinctBuildableOf[Seq, (Variant, (Annotation, Iterable[T]))](
            for (v <- vGen;
                 va <- vaGen(vaSig);
-                ts <- Gen.buildableOfN[Iterable[T], T](sampleIds.length, tGen(v)))
+                ts <- Gen.buildableOfN[Iterable, T](sampleIds.length, tGen(v)))
              yield (v, (va, ts))))
       yield VariantSampleMatrix[T](VariantMetadata(sampleIds, saValues, global, saSig, vaSig, globalSig), sc.parallelize(rows))
 }
 
 object VSMSubgen {
   val random = VSMSubgen[Genotype](
-    sampleIdGen = Gen.distinctBuildableOf[IndexedSeq[String], String](Gen.identifier),
+    sampleIdGen = Gen.distinctBuildableOf[IndexedSeq, String](Gen.identifier),
     saSigGen = Type.genArb,
     vaSigGen = Type.genArb,
     globalSigGen = Type.genArb,

--- a/src/test/scala/org/broadinstitute/hail/variant/GenotypeStreamSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/GenotypeStreamSuite.scala
@@ -10,7 +10,7 @@ object GenotypeStreamSuite {
   object Spec extends Properties("GenotypeStream") {
     property("iterateBuild") = forAll(for (
       v <- Variant.gen;
-      gs <- Gen.buildableOf[Iterable[Genotype], Genotype](Genotype.gen(v)))
+      gs <- Gen.buildableOf[Iterable, Genotype](Genotype.gen(v)))
     yield (v, gs)) { case (v: Variant, it: Iterable[Genotype]) =>
       val b = new GenotypeStreamBuilder(v)
       b ++= it


### PR DESCRIPTION
This shrinks but does not eliminate type arguments to these methods. It
also eliminates the possibility of accidentally specifying the wrong
kinded collection.

Resolves #537