### PR TITLE
Add aggregateintervals function

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ involved in Hail development, email hail@broadinstitute.org.
  - [Quality Control](docs/QC.md)
  - [PCA](docs/PCA.md)
  - [Annotating with the Variant Effect Predictor](docs/VEP.md)
+ - [Computing aggregate statistics on intervals](docs/commands/AggregateIntervals.md)
  - [Filtering](docs/Filtering.md)
  - [Querying using SQL](docs/SQL.md)
  - [Linear regression](docs/LinearRegression.md)

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,7 @@
+Added command `aggregateintervals`.  [Documentation here](docs/AggregateIntervals.md)
+
+____
+
  - **Overhaul of `table` commands that parse text files.**
     - optional type imputation from the first twenty lines.
     - option `-s, --samplecol` in `annotatesamples table` has been replaced by `-e, --sample-expr`.  This no longer takes a column name, but instead takes an expr language transformation of the column names to produce the sample key.  This could still be a column name e.g. `-e Sample`, but it could also be something like `-e FID.split("_")[1]`. 

--- a/docs/Filtering.md
+++ b/docs/Filtering.md
@@ -34,7 +34,7 @@ Usage:
  - `-i | --input <file>` -- path to interval list file
  - `--keep/--remove` -- keep or remove variants within an interval from the file
 
-Hail expects an interval file to contain either three or five fields per line in the following formats: `contig:start-end` or `contig  start  end  direction  target` (tab-separated).  In either case, Hail will use only the `contig`, `start`, and `end` fields.  Each variant is evaluated against each line in the interval file, and any match will mark the variant to be kept / excluded based on the presence of the `--keep` and `--remove` flags.  _Note: "start" and "end" match positions inclusively, e.g. start <= position <= end_
+Hail expects an interval file to contain either three or five fields per line in the following formats: `contig:start-end`, `contig  start  end` (tab-separated), or `contig  start  end  direction  target` (tab-separated).  In either case, Hail will use only the `contig`, `start`, and `end` fields.  Each variant is evaluated against each line in the interval file, and any match will mark the variant to be kept / excluded based on the presence of the `--keep` and `--remove` flags.  _Note: "start" and "end" match positions inclusively, e.g. start <= position <= end_
 
 ```
 $ hail read -i file.vds

--- a/docs/HailExpressionLanguage.md
+++ b/docs/HailExpressionLanguage.md
@@ -105,6 +105,12 @@ Several Hail commands provide the ability to perform a broad array of computatio
       - merge: `merge(struct1, struct2)` -- create a new struct with all fields in struct1 and struct2
       - select and drop: `select` / `drop` -- these take the format `select(struct, identifier1, identifier2, ...)`.  These methods return a subset of the struct.  One could, for example, remove the horrible `CSQ` from the info field of a vds with `annotatevariants expr -c 'va.info = drop(va.info, CSQ)`.  One can select a subset of fields from a table using `select(va.EIGEN, field1, field2, field3)`
 
+  - Object constructors:
+  
+    - Variant: `Variant(chr, pos, ref, alt)`, where chr, ref, are `String`, and `pos` is Int, and `alt` is either a `String` or `Array[String]`
+    - Variant: `Variant(str)`, where str is of the form `CHR:POS:REF:ALT` or `CHR:POS:REF:ALT1,ALT2...ALTN`
+    - Locus: `Locus(chr, pos)`, where chr is a `String` and pos is an `Int`
+    - Interval: `Interval(startLocus, endLocus)`, where startLocus and endLocus are loci
 
 **Note:**
  - All variables and values are case sensitive
@@ -130,6 +136,8 @@ Identifier | Description
 `s` | Sample
 `sa` | Sample annotations
 `g` | Genotype
+`global` | Global annotations
+
 
 ____
 
@@ -139,6 +147,8 @@ Identifier | Description
 :-: | ---
 `s` | Sample
 `sa` | Sample annotations
+`global` | Global annotations
+
 
 ____
 
@@ -148,6 +158,8 @@ Identifier | Description
 :-: | ---
 `v` | Variant
 `va` | Variant annotations
+`global` | Global annotations
+
 
 ### Count
 

--- a/docs/Representation.md
+++ b/docs/Representation.md
@@ -69,6 +69,7 @@ Identifier | Type | Description
 `v.inYNonPar`           |  `Boolean`  | true if chromosome is Y and start is not in pseudo-autosomal region of Y
 `v.altAllele`           | `AltAllele` | The alternate allele (schema below).  **Assumes biallelic.**
 `v.alt`                 | `String`    | Alternate allele sequence.  **Assumes biallelic.**
+`v.locus`               | `Locus`     | Chromosomal locus (chr, pos) of this variant
 
 **AltAllele:** `v.altAlleles[idx]` or `v.altAllele` (biallelic) 
 
@@ -85,6 +86,20 @@ Identifier | Type | Description
  `<altAllele>.isTransition`   | `Boolean` | true if the polymorphism is a purine-purine or pyrimidine-pyrimidine switch
  `<altAllele>.isTransversion` | `Boolean` | true if the polymorphism is a purine-pyrimidine flip
  `<altAllele>.nMismatch`      | `Int`     | the total number of bases in `v.ref` and `v.alt` that do not match
+
+**Locus:** `v.locus` or `Locus(chr, pos)`
+
+Identifier | Type | Description
+--- | :-: | ---
+`<locus>.contig`   |  `String` |  String representation of contig
+`<locus>.position` |  `Int`    |  Chromosomal position
+
+**Interval:** `Interval(locus1, locus2)`
+
+Identifier | Type | Description
+--- | :-: | ---
+`<interval>.start` |  `Locus` | `Locus` object (see above) at the start of the interval (inclusive)
+`<interval>.end`   |  `Locus` | `Locus` object (see above) at the end of the interval (exclusive)
 
 ____ 
  

--- a/docs/commands/AggregateIntervals.md
+++ b/docs/commands/AggregateIntervals.md
@@ -1,0 +1,103 @@
+# `aggregateintervals`
+
+This command allows you to compute statistics for a set of genomic intervals.
+
+#### Command Line Arguments
+
+Argument | Shortcut | Default | Description
+:-: | :-: | :-: | ---
+`--input <intervals path>` | `-i` | **Required** | Path to interval list file
+`--output <export path>` | `-o` | **Required** | Path for output text file
+`--condition <expr>` | `-c` | **Required** | Export expression (see below)
+
+Note that intervals are **left inclusive, right exclusive**.  This means that \[chr1:1, chr1:3\) contains chr1:1 and chr1:2.
+
+____
+
+## Designating output with an expression
+An export expression designates a list of computations to perform, and what these columns are named.  These expressions should take the form `COL_NAME_1 = <expression>, COL_NAME_2 = <expression>, ...`.  See the examples for ideas.
+
+**Namespace in the `aggregateintervals` condition:**
+
+Identifier | Description
+:-: | ---
+`interval` | genomic interval, see the [representation docs](../Representation.md) for details
+`global` | global annotation
+`variants` | Variant [aggregable](../HailExpressionLanguage.md#aggregables).  Aggregator namespace below.
+
+____
+
+**Namespace within `variants` aggregator:**
+
+Identifier | Description
+:-: | ---
+`v` | Variant
+`va` | Variant annotations
+`global` | Global annotations
+
+____
+
+### Example 1:
+
+In this example, we have an interval file as below:
+
+```
+$ cat capture_intervals.txt
+4:1500-123123
+5:1-1000000
+16:29500000-30200000
+```
+
+Perhaps we want to calculate the total number of SNPs, indels, and total variants in these intervals.  We can do this with the following invocation:
+
+```
+$ hail 
+    read -i dataset.vds
+    aggregateintervals
+        -i capture_intervals.txt
+        -o out.txt
+        -c 'n_SNP = variants.count(v.altAllele.isSNP), n_indel = variants.count(v.altAllele.isIndel), n_total = variants.count(true)'
+```
+
+This will write out the following file:
+
+```
+Contig    Start       End         n_SNP   n_indel     n_total
+4         1500        123123      502     51          553
+5         1           1000000     25024   4500        29524
+16        29500000    30200000    17222   2021        19043
+```
+
+The `-c` argument both defines the names of the column headers (n_SNP, n_indel, n_total) as well as the calculations for each interval.
+
+### Example 2:
+
+Now, let's count the number of LOF, missense, and synonymous non-reference calls per interval (perhaps these intervals are exons).
+
+```
+$ cat intervals.txt
+4:1500-123123
+5:1-1000000
+16:29500000-30200000
+```
+
+```
+$ hail 
+    read -i dataset.vds
+    annotatevariants expr -c 'va.n_calls = gs.count(g.isCalledNonRef)'
+    aggregateintervals
+        -i intervals.txt
+        -o out.txt
+        -c 'LOF_CALLS = variants.statsif(va.consequence == "LOF", va.n_calls).sum,
+            MISSENSE_CALLS = variants.statsif(va.consequence == "missense", va.n_calls).sum,
+            SYN_CALLS = variants.statsif(va.consequence == "synonymous", va.n_calls).sum'
+```
+
+We will get something that looks like the following output:
+
+```
+Contig    Start       End         LOF_CALLS   MISSENSE_CALLS   SYN_CALLS
+4         1500        123123      42          122              553
+5         1           1000000     3           12               66
+16        29500000    30200000    17          22               202
+```

--- a/src/main/scala/org/broadinstitute/hail/driver/AggregateIntervals.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/AggregateIntervals.scala
@@ -1,0 +1,123 @@
+package org.broadinstitute.hail.driver
+
+import org.broadinstitute.hail.Utils._
+import org.broadinstitute.hail.annotations.Annotation
+import org.broadinstitute.hail.expr._
+import org.broadinstitute.hail.io.annotators.IntervalListAnnotator
+import org.broadinstitute.hail.methods._
+import org.broadinstitute.hail.utils.Interval
+import org.broadinstitute.hail.variant._
+import org.kohsuke.args4j.{Option => Args4jOption}
+
+import scala.collection.mutable
+
+object AggregateIntervals extends Command {
+
+  class Options extends BaseOptions {
+
+    @Args4jOption(required = true, name = "-o", aliases = Array("--output"),
+      usage = "path of output file")
+    var output: String = _
+
+    @Args4jOption(required = true, name = "-c", aliases = Array("--condition"),
+      usage = ".columns file, or comma-separated list of fields/computations")
+    var condition: String = _
+
+    @Args4jOption(required = true, name = "-i", usage = "path to interval file")
+    var input: String = _
+
+  }
+
+  def newOptions = new Options
+
+  def name = "aggregateintervals"
+
+  def description = "Aggregate and export information over intervals"
+
+  def supportsMultiallelic = true
+
+  def requiresVDS = true
+
+  def run(state: State, options: Options): State = {
+    val vds = state.vds
+    val sc = vds.sparkContext
+    val cond = options.condition
+    val output = options.output
+    val vas = vds.vaSignature
+    val sas = vds.saSignature
+
+    val aggregationEC = EvalContext(Map(
+      "v" -> (0, TVariant),
+      "va" -> (1, vds.vaSignature),
+      "global" -> (2, vds.globalSignature)))
+    val symTab = Map(
+      "interval" -> (0, TInterval),
+      "global" -> (1, vds.globalSignature),
+      "variants" -> (-1, TAggregable(aggregationEC)))
+
+    val ec = EvalContext(symTab)
+    ec.set(1, vds.globalAnnotation)
+    aggregationEC.set(2, vds.globalAnnotation)
+
+    val (header, parseResults) = if (cond.endsWith(".columns")) {
+      Parser.parseColumnsFile(ec, cond, vds.sparkContext.hadoopConfiguration)
+    } else {
+      val ret = Parser.parseNamedArgs(cond, ec)
+      (ret.map(_._1), ret.map(x => (x._2, x._3)))
+    }
+
+    if (header.isEmpty)
+      fatal("this module requires one or more named expr arguments")
+
+    val (zVals, seqOp, combOp, resultOp) = Aggregators.makeFunctions(aggregationEC)
+
+    val zvf: () => Array[Any] = () => zVals.indices.map(zVals).toArray
+
+    val variantAggregations = Aggregators.buildVariantaggregations(vds, aggregationEC)
+
+    val iList = IntervalListAnnotator.read(options.input, sc.hadoopConfiguration)
+    val iListBc = sc.broadcast(iList)
+
+    val results = vds.variantsAndAnnotations.flatMap { case (v, va) =>
+      iListBc.value.query(v.locus).map { i => (i, (v, va)) }
+    }
+      .aggregateByKey(zvf())(seqOp, combOp)
+      .collectAsMap()
+
+    writeTextFile(options.output, sc.hadoopConfiguration) { out =>
+      val sb = new StringBuilder
+      sb.append("Contig")
+      sb += '\t'
+      sb.append("Start")
+      sb += '\t'
+      sb.append("End")
+      header.foreach { col =>
+        sb += '\t'
+        sb.append(col)
+      }
+      sb += '\n'
+
+      iList.toIterator
+        .foreachBetween { interval =>
+
+          sb.append(interval.start.contig)
+          sb += '\t'
+          sb.append(interval.start.position)
+          sb += '\t'
+          sb.append(interval.end.position)
+          val res = results.getOrElse(interval, zvf())
+          resultOp(res)
+
+          ec.set(0, interval)
+          parseResults.foreach { case (t, f) =>
+            sb += '\t'
+            sb.append(t.str(f().getOrElse("NA")))
+          }
+        }(sb += '\n')
+
+      out.write(sb.result())
+    }
+
+    state
+  }
+}

--- a/src/main/scala/org/broadinstitute/hail/driver/Command.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Command.scala
@@ -44,6 +44,7 @@ object ToplevelCommands {
         + cmd.description))
   }
 
+  register(AggregateIntervals)
   register(AnnotateSamples)
   register(AnnotateVariants)
   register(AnnotateGlobal)

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsIntervals.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsIntervals.scala
@@ -38,8 +38,8 @@ object FilterVariantsIntervals extends Command {
 
     val cond = options.input
     val keep = options.keep
-    val gis = IntervalListAnnotator.read(options.input, state.hadoopConf)
+    val ilist = IntervalListAnnotator.read(options.input, state.hadoopConf)
 
-    state.copy(vds = vds.filterIntervals(gis, options.keep))
+    state.copy(vds = vds.filterIntervals(ilist, options.keep))
   }
 }

--- a/src/main/scala/org/broadinstitute/hail/expr/Parser.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/Parser.scala
@@ -405,6 +405,7 @@ object Parser extends JavaTokenParsers {
 
   def type_expr: Parser[Type] =
     "Empty" ^^ { _ => TStruct.empty } |
+      "Interval" ^^ { _ => TInterval } |
       "Boolean" ^^ { _ => TBoolean } |
       "Char" ^^ { _ => TChar } |
       "Int" ^^ { _ => TInt } |

--- a/src/main/scala/org/broadinstitute/hail/expr/Type.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/Type.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.annotations.{Annotation, AnnotationPathException, _}
 import org.broadinstitute.hail.check.Arbitrary._
 import org.broadinstitute.hail.check.{Gen, _}
-import org.broadinstitute.hail.utils.StringEscapeUtils
+import org.broadinstitute.hail.utils.{Interval, StringEscapeUtils}
 import org.broadinstitute.hail.variant.{AltAllele, Genotype, Locus, Variant}
 import org.json4s._
 import org.json4s.jackson.JsonMethods
@@ -20,7 +20,7 @@ sealed abstract class BaseType extends Serializable {
 
 object Type {
   val genScalar = Gen.oneOf[Type](TBoolean, TChar, TInt, TLong, TFloat, TDouble, TString,
-    TVariant, TAltAllele, TGenotype, TLocus)
+    TVariant, TAltAllele, TGenotype, TLocus, TInterval)
 
   def genSized(size: Int): Gen[Type] = {
     if (size < 1)
@@ -331,6 +331,14 @@ case object TLocus extends Type {
   def typeCheck(a: Any): Boolean = a == null || a.isInstanceOf[Locus]
 
   override def genValue: Gen[Annotation] = Locus.gen
+}
+
+case object TInterval extends Type {
+  override def toString = "Interval"
+
+  def typeCheck(a: Any): Boolean = a == null || a.isInstanceOf[Interval[_]] && a.asInstanceOf[Interval[_]].end.isInstanceOf[Locus]
+
+  override def genValue: Gen[Annotation] = Interval.gen(Locus.gen)
 }
 
 case class Field(name: String, `type`: Type,

--- a/src/main/scala/org/broadinstitute/hail/utils/IntervalTree.scala
+++ b/src/main/scala/org/broadinstitute/hail/utils/IntervalTree.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.hail.utils
 
 import org.broadinstitute.hail.check._
+import org.json4s.JValue
+import org.json4s.JsonAST.JObject
 
 import scala.collection.mutable
 import scala.math.Ordering.Implicits._
@@ -23,6 +25,8 @@ case class Interval[T](start: T, end: T)(implicit ev: Ordering[T]) extends Order
 
     ev.compare(end, that.end)
   }
+
+  def toJSON(f: (T) => JValue): JValue = JObject("start" -> f(start), "end" -> f(end))
 }
 
 object Interval {

--- a/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/VariantSampleMatrix.scala
@@ -28,7 +28,6 @@ object VariantSampleMatrix {
     new VariantSampleMatrix(metadata, rdd)
   }
 
-
   private def readMetadata(sqlContext: SQLContext, dirname: String,
     requireParquetSuccess: Boolean = true): VariantMetadata = {
     if (!dirname.endsWith(".vds") && !dirname.endsWith(".vds/"))
@@ -125,7 +124,7 @@ object VariantSampleMatrix {
 
   def read(sqlContext: SQLContext, dirname: String, skipGenotypes: Boolean = false): VariantDataset = {
 
-    val metadata = readMetadata(sqlContext, dirname, skipGenotypes)
+    val metadata = readMetadata(sqlContext, dirname)
     val vaSignature = metadata.vaSignature
 
     val df = sqlContext.read.parquet(dirname + "/rdd.parquet")
@@ -388,10 +387,10 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
   def filterVariants(p: (Variant, Annotation, Iterable[T]) => Boolean): VariantSampleMatrix[T] =
     copy(rdd = rdd.filter { case (v, (va, gs)) => p(v, va, gs) })
 
-  def filterIntervals(gis: IntervalTree[Locus], keep: Boolean = true): VariantSampleMatrix[T] = {
-    val gisBc = sparkContext.broadcast(gis)
+  def filterIntervals(iList: IntervalTree[Locus], keep: Boolean = true): VariantSampleMatrix[T] = {
+    val iListBc = sparkContext.broadcast(iList)
     filterVariants { (v, va, gs) =>
-      val inInterval = gisBc.value.contains(v.locus)
+      val inInterval = iListBc.value.contains(v.locus)
       if (keep)
         inInterval
       else
@@ -577,18 +576,21 @@ class VariantSampleMatrix[T](val metadata: VariantMetadata,
               |  left:  $wasSplit
               |  right: ${ that.wasSplit }""".stripMargin)
     }
+    var printed = false
     metadataSame &&
       rdd
         .fullOuterJoin(that.rdd)
         .forall {
           case (v, (Some((va1, it1)), Some((va2, it2)))) =>
             val annotationsSame = va1 == va2
-            if (!annotationsSame)
+            if (!annotationsSame && !printed) {
               println(
                 s"""at variant `$v', annotations were not the same:
                     |  $va1
                     |  $va2
                  """.stripMargin)
+              printed = true
+            }
             val genotypesSame = (it1, it2).zipped.forall { case (g1, g2) =>
               if (g1 != g2)
                 println(s"genotypes $g1, $g2 were not the same")

--- a/src/test/scala/org/broadinstitute/hail/variant/IntervalSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/IntervalSuite.scala
@@ -1,15 +1,18 @@
 package org.broadinstitute.hail.variant
 
 import org.broadinstitute.hail.SparkSuite
+import org.broadinstitute.hail.Utils._
 import org.broadinstitute.hail.check.{Gen, Prop}
-import org.broadinstitute.hail.driver.{AnnotateVariantsIntervals, ImportVCF, State}
+import org.broadinstitute.hail.driver._
 import org.broadinstitute.hail.expr.{TSet, TString}
 import org.broadinstitute.hail.io.annotators.IntervalListAnnotator
+import org.broadinstitute.hail.methods.LoadVCF
 import org.broadinstitute.hail.utils._
-import org.broadinstitute.hail.Utils._
 import org.testng.annotations.Test
 
-class IntervalListSuite extends SparkSuite {
+import scala.io.Source
+
+class IntervalSuite extends SparkSuite {
 
   def genomicInterval(contig: String, start: Int, end: Int): Interval[Locus] =
     Interval(Locus(contig, start),
@@ -124,6 +127,64 @@ class IntervalListSuite extends SparkSuite {
         simpleAssert(a == Set("A"))
       else
         simpleAssert(a.isEmpty)
+    }
+
+    @Test def testAggregate() {
+      val vds = LoadVCF(sc, "src/test/resources/sample2.vcf", nPartitions = Some(2)).cache()
+      val state = SplitMulti.run(State(sc, sqlContext, vds))
+      val iList = tmpDir.createTempFile("input", ".interval_list")
+      val tmp1 = tmpDir.createTempFile("output", ".tsv")
+
+      val startPos = 16050036 - 250000
+      val endPos = 17421565 + 250000
+      val intervalGen = for (start <- Gen.choose(startPos, endPos);
+                             end <- Gen.choose(start, endPos))
+        yield Interval(Locus("22", start), Locus("22", end))
+      val intervalsGen = Gen.buildableOfN[Array, Interval[Locus]](500, intervalGen)
+
+      val p = Prop.forAll(intervalsGen) { intervals =>
+
+        writeTextFile(iList, hadoopConf) { out =>
+          intervals.foreach { i =>
+            out.write(s"22\t${ i.start.position }\t${ i.end.position }\n")
+          }
+        }
+
+        AggregateIntervals.run(state, Array(
+          "-i", iList,
+          "-o", tmp1,
+          "-c", "nSNP = variants.count(v.altAllele.isSNP), nIndel = variants.count(v.altAllele.isIndel), N = variants.count(true)"))
+
+        val variants = state
+          .vds
+          .variants
+          .collect()
+
+        readFile(tmp1, hadoopConf) { in =>
+
+          Source.fromInputStream(in)
+            .getLines()
+            .toArray
+            .tail
+            .forall { line =>
+              val Array(contig, startStr, endStr, nSnpStr, nIndelStr, nStr) = line.split("\t")
+              val start = startStr.toInt
+              val end = endStr.toInt
+              val nSnp = nSnpStr.toInt
+              val nIndel = nIndelStr.toInt
+              val n = nStr.toInt
+
+              val interval = Interval(Locus(contig, start), Locus(contig, end))
+              val inInterval = variants.filter(v => interval.contains(v.locus))
+
+              (nSnp == inInterval.count(_.altAllele.isSNP)) &&
+                (nIndel == inInterval.count(_.altAllele.isIndel)) &&
+                (n == inInterval.length)
+            }
+        }
+      }
+
+      p.check(count = 100)
     }
   }
 }


### PR DESCRIPTION
Add new command to aggregate and export statistics over intervals with
access to a 'variants' aggregator.  Takes an interval list as input,
takes an export command (see exportvariants), and an output path.

Exposed `Interval` in the expr language, which has `start`, `end`,
and `contains` (all locus-based).

Reworked property-based testing for annotation impexes.