### PR TITLE
Testing improvements.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,20 +101,23 @@ dependencies {
     testCompile 'org.scalatest:scalatest_' + scalaMajorVersion + ':2.2.4'
 }
 
+task(checkSettings) << {
+    def checkSeed = System.getProperty("check.seed", "1")
+    if (checkSeed == "random")
+        checkSeed = new Random().nextInt().toString()
+    def checkSize = System.getProperty("check.size", "1000")
+    def checkCount = System.getProperty("check.count", "10")
+
+    println "check: seed = $checkSeed, size = $checkSize, count = $checkCount"
+
+    // override with these defaults, random seed
+    System.setProperty("check.seed", checkSeed)
+    System.setProperty("check.size", checkSize)
+    System.setProperty("check.count", checkCount)
+}
+
 test {
     useTestNG {}
-
-    Random random = new Random()
-
-    def randomize = System.getProperty("hail.randomize","false").toBoolean()
-    def randomSeed = random.nextInt()
-
-    if (randomize) {System.setProperty("hail.seed", randomSeed.toString())
-    } else if (System.getProperty("hail.seed") == null) {
-        System.setProperty("hail.seed", "1")
-    }
-    def seed = System.getProperty("hail.seed")
-    println "Using a seed of [$seed] for testing."
 
     systemProperties System.getProperties()
 
@@ -127,6 +130,8 @@ test {
         logger.lifecycle("Running test: " + descriptor)
     }
 }
+
+test.dependsOn(checkSettings)
 
 tasks.withType(ShadowJar) {
     manifest {

--- a/src/main/scala/org/broadinstitute/hail/Utils.scala
+++ b/src/main/scala/org/broadinstitute/hail/Utils.scala
@@ -639,7 +639,7 @@ class RichBoolean(val b: Boolean) extends AnyVal {
 }
 
 trait Logging {
-  @transient var log_ : Logger = null
+  @transient var log_ : Logger = _
 
   def log: Logger = {
     if (log_ == null)

--- a/src/test/scala/org/broadinstitute/hail/io/LoadBgenSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/io/LoadBgenSuite.scala
@@ -143,6 +143,6 @@ class LoadBgenSuite extends SparkSuite {
   }
 
   @Test def testBgenImportRandom() {
-    Spec.check(100, 50, Option(20))
+    Spec.check()
   }
 }

--- a/src/test/scala/org/broadinstitute/hail/methods/ExprSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ExprSuite.scala
@@ -7,7 +7,6 @@ import org.broadinstitute.hail.check.Properties
 import org.broadinstitute.hail.expr._
 import org.broadinstitute.hail.utils.Interval
 import org.broadinstitute.hail.utils.StringEscapeUtils._
-import org.broadinstitute.hail.variant.GenotypeSuite.Spec.{check => _}
 import org.broadinstitute.hail.variant.{Genotype, Locus, Variant}
 import org.broadinstitute.hail.{FatalException, SparkSuite, TestUtils}
 import org.json4s._
@@ -427,7 +426,7 @@ class ExprSuite extends SparkSuite {
       s == unescapeString(escapeString(s))
     }
 
-    p.check(count = 1000)
+    p.check()
   }
 
   @Test def testImpexes() {

--- a/src/test/scala/org/broadinstitute/hail/methods/ImportAnnotationsSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/methods/ImportAnnotationsSuite.scala
@@ -505,7 +505,7 @@ class ImportAnnotationsSuite extends SparkSuite {
       state.vds.same(vds)
     }
 
-    p.check(count = 1)
+    p.check()
   }
 
   @Test def testPositions() {

--- a/src/test/scala/org/broadinstitute/hail/stats/FisherExactTestSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/stats/FisherExactTestSuite.scala
@@ -130,6 +130,6 @@ class FisherExactTestSuite extends SparkSuite {
   }
 
   @Test def testFisherExactTest() {
-    Spec.check(count = 100)
+    Spec.check()
   }
 }

--- a/src/test/scala/org/broadinstitute/hail/variant/GenotypeSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/GenotypeSuite.scala
@@ -90,6 +90,6 @@ class GenotypeSuite extends TestNGSuite {
     assert(D_==(Genotype(Some(1), Some(Array(16, 16)), Some(33), Some(99), Some(Array(100, 0, 100))).pAB().get, 1.0))
     assert(D_==(Genotype(Some(1), Some(Array(5, 8)), Some(13), Some(99), Some(Array(200, 0, 100))).pAB().get, 0.423950))
 
-    Spec.check(size = 100, count = 10000)
+    Spec.check()
   }
 }

--- a/src/test/scala/org/broadinstitute/hail/variant/IntervalSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/IntervalSuite.scala
@@ -184,7 +184,7 @@ class IntervalSuite extends SparkSuite {
         }
       }
 
-      p.check(count = 100)
+      p.check()
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/vsm/VSMSuite.scala
@@ -247,7 +247,7 @@ class VSMSuite extends SparkSuite {
     assert(s.vds.same(s2.vds))
   }
 
-  @Test def testVSMGenIsLinearSpaceInSizeParameter() {
+  @Test(enabled = false) def testVSMGenIsLinearSpaceInSizeParameter() {
     val minimumRSquareValue = 0.8
     def vsmOfSize(size: Int): VariantSampleMatrix[Genotype] = {
       val parameters = Parameters(new RandomDataGenerator(), size, 1)


### PR DESCRIPTION
Tests now take ~2m40 on my laptop.  With -Dcheck.size=100 -Dcheck.count=1, they take about ~1m20.  A huge part of the test time was (re)creating the SparkContext.

I disabled testVSMGenIsLinearSpaceInSizeParameter.  It doesn't quite make sense to me to be spending half our test time budget verifying ... that our tests aren't taking too long.  Happy to discuss it on Monday.

Following Jackie's original code, the duplicated logic and defaults for check settings in Prop and gradle are needed to include the check settings (in particular, the seed) in the gradle output when you're not using `--info` or similar.  I couldn't figure out another way to do it.

Changes:

Set seed with -Dcheck.seed=seed, random with -Dcheck.seed=random.
Added SparkManager to store sc and sqlContext.
Reuse sc between tests.
Added -Dcheck.size=size and -Dcheck.count=count.
Removed Prop.check with count, size options.
Disabled testVSMGenIsLinearSpaceInSizeParameter.
