### PR TITLE
add website skeleton

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Hail</title>
+    <link rel="stylesheet" href="style.css" type="text/css">
+    <link href='https://fonts.googleapis.com/css?family=Lora'
+          rel='stylesheet'
+          type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Montserrat'
+          rel='stylesheet'
+          type='text/css'>
+  </head>
+  <body>
+    <div id="body">
+      <h1>Hail is</h1>
+      <p>a framework for scalable genetic data analysis. Hail is pre-alpha software
+        and under active development. Hail is written in Scala (mostly) and uses
+        Apache <a href="http://spark.apache.org/">Spark</a> and other Apache Hadoop
+        projects. If you are interested in getting involved in Hail development,
+        email <a href="mailto:hail@broadinstitute.org">hail@broadinstitute.org</a>.</p>
+      <p>The hail source code is located at <a href="https://github.com/broadinstitute/hail">github</a></p>
+    </div>
+  </body>
+</html>

--- a/html/style.css
+++ b/html/style.css
@@ -1,0 +1,15 @@
+body {
+  font-size: 20px;
+  line-height: 125%;
+  font-family: 'Lora', serif;
+}
+
+div#body {
+  margin-left: auto;
+  margin-right: auto;
+  width: 40em;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Montserrat', sans-serif;
+}


### PR DESCRIPTION
I've added the current contents of `hail.is`'s `/var/www/html` to the `html` folder of our repo.

I'm not sure if we want to version control the website. If we do, I'm not sure in which repository it should live.