### PR TITLE
Properly print full stacktrace on error.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/Main.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/Main.scala
@@ -94,11 +94,11 @@ object Main {
     fail(msg)
   }
 
-
-  def expandException(cmd: Command, e: Throwable): String =
-    s"${ e.getClass.getName }: ${ e.getMessage }\n\tat ${ e.getStackTrace.mkString("\n\tat ") }${
-      Option(e.getCause).foreach(exception => expandException(cmd, exception))
+  def expandException(cmd: Command, e: Throwable): String = {
+    s"${ e.getClass.getName }: ${ e.getLocalizedMessage }\n\tat ${ e.getStackTrace.mkString("\n\tat ") }${
+      Option(e.getCause).map(exception => expandException(cmd, exception)).getOrElse("")
     }"
+  }
 
   def handlePropagatedException(cmd: Command, e: Throwable) {
     e match {
@@ -113,10 +113,9 @@ object Main {
     } catch {
       case e: Exception =>
         handlePropagatedException(cmd, e)
-        val msg = s"hail: ${ cmd.name }: caught exception: "
-        //        log.error(msg)
-        log.error(msg + expandException(cmd, e))
-        System.err.println(msg + e.getMessage)
+        val msg = s"hail: ${ cmd.name }: caught exception: ${ expandException(cmd, e) }"
+        log.error(msg)
+        System.err.println(msg)
         sys.exit(1)
     }
   }


### PR DESCRIPTION
```
hail gen annotateglobal expr -c 'global = index([{a: "hello", b: 5}], a).mapValues(x => x.b)' annotatevariants expr -c 'va = global["hello"]' count
hail: info: running: gen
hail: info: running: annotateglobal expr -c 'global = index([{a: "hello", b: 5}], a).mapValues(x => x.b)'
hail: info: running: annotatevariants expr -c 'va = global["hello"]'
hail: annotatevariants expr: caught exception: org.apache.spark.SparkException: Task not serializable
       	at org.apache.spark.util.ClosureCleaner$.ensureSerializable(ClosureCleaner.scala:304)
       	at org.apache.spark.util.ClosureCleaner$.org$apache$spark$util$ClosureCleaner$$clean(ClosureCleaner.scala:294)
       	at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:122)
       	at org.apache.spark.SparkContext.clean(SparkContext.scala:2021)
       	at org.apache.spark.rdd.RDD$$anonfun$map$1.apply(RDD.scala:314)
       	at org.apache.spark.rdd.RDD$$anonfun$map$1.apply(RDD.scala:313)
       	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:147)
       	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:108)
       	at org.apache.spark.rdd.RDD.withScope(RDD.scala:306)
       	at org.apache.spark.rdd.RDD.map(RDD.scala:313)
       	at org.broadinstitute.hail.variant.VariantSampleMatrix.mapAnnotations(VariantSampleMatrix.scala:396)
       	at org.broadinstitute.hail.driver.AnnotateVariantsExpr$.run(AnnotateVariantsExpr.scala:65)
       	at org.broadinstitute.hail.driver.AnnotateVariantsExpr$.run(AnnotateVariantsExpr.scala:11)
       	at org.broadinstitute.hail.driver.Command.runCommand(Command.scala:239)
       	at org.broadinstitute.hail.driver.Main$.runCommand(Main.scala:112)
       	at org.broadinstitute.hail.driver.Main$$anonfun$runCommands$1$$anonfun$1.apply(Main.scala:137)
       	at org.broadinstitute.hail.driver.Main$$anonfun$runCommands$1$$anonfun$1.apply(Main.scala:137)
       	at org.broadinstitute.hail.Utils$.time(Utils.scala:1185)
       	at org.broadinstitute.hail.driver.Main$$anonfun$runCommands$1.apply(Main.scala:136)
       	at org.broadinstitute.hail.driver.Main$$anonfun$runCommands$1.apply(Main.scala:130)
       	at scala.collection.IndexedSeqOptimized$class.foldl(IndexedSeqOptimized.scala:51)
       	at scala.collection.IndexedSeqOptimized$class.foldLeft(IndexedSeqOptimized.scala:60)
       	at scala.collection.mutable.ArrayOps$ofRef.foldLeft(ArrayOps.scala:108)
       	at org.broadinstitute.hail.driver.Main$.runCommands(Main.scala:130)
       	at org.broadinstitute.hail.driver.Main$.main(Main.scala:283)
       	at org.broadinstitute.hail.driver.Main.main(Main.scala)java.io.NotSerializableException: scala.collection.immutable.MapLike$$anon$2
Serialization stack:
       	- object not serializable (class: scala.collection.immutable.MapLike$$anon$2, value: Map(hello -> 5))
       	- element of array (index: 2)
       	- array (class [Ljava.lang.Object;, size 16)
       	- field (class: scala.collection.mutable.ArrayBuffer, name: array, type: class [Ljava.lang.Object;)
       	- object (class scala.collection.mutable.ArrayBuffer, ArrayBuffer(null, null, Map(hello -> 5)))
       	- field (class: org.broadinstitute.hail.expr.EvalContext, name: a, type: class scala.collection.mutable.ArrayBuffer)
       	- object (class org.broadinstitute.hail.expr.EvalContext, EvalContext(Map(v -> (0,Variant), va -> (1,Locus), global -> (2,Dict[Int]), gs -> (-1,Aggregable)),ArrayBuffer(null, null, Map(hello -> 5)),ArrayBuffer()))
       	- field (class: org.broadinstitute.hail.driver.AnnotateVariantsExpr$$anonfun$2, name: ec$1, type: class org.broadinstitute.hail.expr.EvalContext)
       	- object (class org.broadinstitute.hail.driver.AnnotateVariantsExpr$$anonfun$2, <function3>)
       	- field (class: org.broadinstitute.hail.variant.VariantSampleMatrix$$anonfun$mapAnnotations$1, name: f$1, type: interface scala.Function3)
       	- object (class org.broadinstitute.hail.variant.VariantSampleMatrix$$anonfun$mapAnnotations$1, <function1>)
       	at org.apache.spark.serializer.SerializationDebugger$.improveException(SerializationDebugger.scala:40)
       	at org.apache.spark.serializer.JavaSerializationStream.writeObject(JavaSerializer.scala:47)
       	at org.apache.spark.serializer.JavaSerializerInstance.serialize(JavaSerializer.scala:84)
       	at org.apache.spark.util.ClosureCleaner$.ensureSerializable(ClosureCleaner.scala:301)
       	at org.apache.spark.util.ClosureCleaner$.org$apache$spark$util$ClosureCleaner$$clean(ClosureCleaner.scala:294)
       	at org.apache.spark.util.ClosureCleaner$.clean(ClosureCleaner.scala:122)
       	at org.apache.spark.SparkContext.clean(SparkContext.scala:2021)
       	at org.apache.spark.rdd.RDD$$anonfun$map$1.apply(RDD.scala:314)
       	at org.apache.spark.rdd.RDD$$anonfun$map$1.apply(RDD.scala:313)
       	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:147)
       	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:108)
       	at org.apache.spark.rdd.RDD.withScope(RDD.scala:306)
       	at org.apache.spark.rdd.RDD.map(RDD.scala:313)
       	at org.broadinstitute.hail.variant.VariantSampleMatrix.mapAnnotations(VariantSampleMatrix.scala:396)
       	at org.broadinstitute.hail.driver.AnnotateVariantsExpr$.run(AnnotateVariantsExpr.scala:65)
       	at org.broadinstitute.hail.driver.AnnotateVariantsExpr$.run(AnnotateVariantsExpr.scala:11)
       	at org.broadinstitute.hail.driver.Command.runCommand(Command.scala:239)
       	at org.broadinstitute.hail.driver.Main$.runCommand(Main.scala:112)
       	at org.broadinstitute.hail.driver.Main$$anonfun$runCommands$1$$anonfun$1.apply(Main.scala:137)
       	at org.broadinstitute.hail.driver.Main$$anonfun$runCommands$1$$anonfun$1.apply(Main.scala:137)
       	at org.broadinstitute.hail.Utils$.time(Utils.scala:1185)
       	at org.broadinstitute.hail.driver.Main$$anonfun$runCommands$1.apply(Main.scala:136)
       	at org.broadinstitute.hail.driver.Main$$anonfun$runCommands$1.apply(Main.scala:130)
       	at scala.collection.IndexedSeqOptimized$class.foldl(IndexedSeqOptimized.scala:51)
       	at scala.collection.IndexedSeqOptimized$class.foldLeft(IndexedSeqOptimized.scala:60)
       	at scala.collection.mutable.ArrayOps$ofRef.foldLeft(ArrayOps.scala:108)
       	at org.broadinstitute.hail.driver.Main$.runCommands(Main.scala:130)
       	at org.broadinstitute.hail.driver.Main$.main(Main.scala:283)
```