### PR TITLE
fix & make uniform mut-ex of keep/remove

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/driver/FilterGenotypes.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterGenotypes.scala
@@ -37,8 +37,8 @@ object FilterGenotypes extends Command {
     val vas = vds.vaSignature
     val sas = vds.saSignature
 
-    if (!options.keep && !options.remove)
-      fatal(name + ": one of `--keep' or `--remove' required")
+    if (!(options.keep ^ options.remove))
+      fatal("either `--keep' or `--remove' required, but not both")
 
     val keep = options.keep
 

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterSamplesExpr.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterSamplesExpr.scala
@@ -35,9 +35,8 @@ object FilterSamplesExpr extends Command {
   def run(state: State, options: Options): State = {
     val vds = state.vds
 
-    if ((options.keep && options.remove)
-      || (!options.keep && !options.remove))
-      fatal("one `--keep' or `--remove' required, but not both")
+    if (!(options.keep ^ options.remove))
+      fatal("either `--keep' or `--remove' required, but not both")
 
     val keep = options.keep
     val sas = vds.saSignature

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterSamplesList.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterSamplesList.scala
@@ -34,9 +34,8 @@ object FilterSamplesList extends Command {
   def run(state: State, options: Options): State = {
     val vds = state.vds
 
-    if ((options.keep && options.remove)
-      || (!options.keep && !options.remove))
-      fatal("one `--keep' or `--remove' required, but not both")
+    if (!(options.keep ^ options.remove))
+      fatal("either `--keep' or `--remove' required, but not both")
 
     val keep = options.keep
     val samples = readFile(options.input, state.hadoopConf) { reader =>

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsExpr.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsExpr.scala
@@ -37,9 +37,8 @@ object FilterVariantsExpr extends Command {
   def run(state: State, options: Options): State = {
     val vds = state.vds
 
-    if ((options.keep && options.remove)
-      || (!options.keep && !options.remove))
-      fatal("one `--keep' or `--remove' required, but not both")
+    if (!(options.keep ^ options.remove))
+      fatal("either `--keep' or `--remove' required, but not both")
 
     val vas = vds.vaSignature
     val cond = options.condition

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsIntervals.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsIntervals.scala
@@ -32,9 +32,8 @@ object FilterVariantsIntervals extends Command {
   def run(state: State, options: Options): State = {
     val vds = state.vds
 
-    if ((options.keep && options.remove)
-      || (!options.keep && !options.remove))
-      fatal("one `--keep' or `--remove' required, but not both")
+    if (!(options.keep ^ options.remove))
+      fatal("either `--keep' or `--remove' required, but not both")
 
     val cond = options.input
     val keep = options.keep

--- a/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsList.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/FilterVariantsList.scala
@@ -32,9 +32,8 @@ object FilterVariantsList extends Command {
   def run(state: State, options: Options): State = {
     val vds = state.vds
 
-    if ((options.keep && options.remove)
-      || (!options.keep && !options.remove))
-      fatal("one `--keep' or `--remove' required, but not both")
+    if (!(options.keep ^ options.remove))
+      fatal("either `--keep' or `--remove' required, but not both")
 
     val keep = options.keep
 


### PR DESCRIPTION
1. `FilterGenotypes` now correctly errs when both keep and remove
   are specified

2. All other filters now use xor, `^`, for the condition