### PR TITLE
Converted tables in Importing.md to HTML.

### DIFF
--- a/docs/Importing.md
+++ b/docs/Importing.md
@@ -4,24 +4,33 @@ Hail does not operate directly on input files.  Hail uses a fast and storage-eff
 
 ### Supported Data Types:
 
-Hail Command | Extensions | File Spec
---- | :-: | ---
-[`importvcf`](#importvcf) | .vcf .vcf.bgz .vcf.gz     | [VCF file](https://samtools.github.io/hts-specs/VCFv4.2.pdf)
-[`importplink`](#importplink) | .bed .bim .fam | [PLINK binary dataset](http://pngu.mgh.harvard.edu/~purcell/plink/data.shtml#bed)
-[`importgen`](#importgen) | .gen .sample     | [GEN file](http://www.stats.ox.ac.uk/%7Emarchini/software/gwas/file_format.html#mozTocId40300)
-[`importbgen`](#importbgen) | .bgen .sample     | [BGEN file](http://www.well.ox.ac.uk/~gav/bgen_format/bgen_format_v1.1.html)
-
+<table>
+<thead>
+<tr><th>Hail Command</th><th>Extensions</th><th>File Spec</th></tr>
+</thead>
+<tbody>
+<tr><td>[`importvcf`](#importvcf)</td><td>.vcf .vcf.bgz .vcf.gz</td><td>[VCF file](https://samtools.github.io/hts-specs/VCFv4.2.pdf)</td></tr>
+<tr><td>[`importplink`](#importplink)</td><td>.bed .bim .fam</td><td>[PLINK binary dataset](http://pngu.mgh.harvard.edu/~purcell/plink/data.shtml#bed)</td></tr>
+<tr><td>[`importgen`](#importgen)</td><td>.gen .sample</td><td>[GEN file](http://www.stats.ox.ac.uk/%7Emarchini/software/gwas/file_format.html#mozTocId40300)</td></tr>
+<tr><td>[`importbgen`](#importbgen)</td><td>.bgen .sample</td><td>[BGEN file](http://www.well.ox.ac.uk/~gav/bgen_format/bgen_format_v1.1.html)</td></tr>
+</tbody>
+</table>
 
 ### <a name="hadoopglob"></a> Hadoop Glob Patterns:
 All of these commands take a list of files to load. Files can be specified as Hadoop glob patterns:
 
-Character | Description
---- | :-: | ---
-`?` | Matches any single character.
-`*` | Matches zero or more characters.
-`[abc]` | Matches a single character from character set {a,b,c}.
-`[a-b]` | Matches a single character from the character range {a...b}. Note that character a must be lexicographically less than or equal to character b.
-`[^a]`  | Matches a single character that is not from character set or range {a}. Note that the ^ character must occur immediately to the right of the opening bracket.
-`\c`  | Removes (escapes) any special meaning of character c.
-`{ab,cd}` | Matches a string from the string set {ab, cd}.
-`{ab,c{de,fh}}` | Matches a string from the string set {ab, cde, cfh}.
+<table>
+<thead>
+<tr><th>Character</th><th>Description</th></tr>
+</thead>
+<tbody>
+<tr><td>`?`</td><td>Matches any single character.</td></tr>
+<tr><td>`*`</td><td>Matches zero or more characters.</td></tr>
+<tr><td>`[abc]`</td><td>Matches a single character from character set {a,b,c}.</td></tr>
+<tr><td>`[a-b]`</td><td>Matches a single character from the character range {a...b}. Note that character a must be lexicographically less than or equal to character b.</td></tr>
+<tr><td>`[^a]` </td><td>Matches a single character tat is not from character set or range {a}. Note that the ^ character must occur immediately to the right of the opening bracket.</td></tr>
+<tr><td>`\c` </td><td>Removes (escapes) any special meaning of character c.</td></tr>
+<tr><td>`{ab,cd}`</td><td>Matches a string from the string set {ab, cd}.</td></tr>
+<tr><td>`{ab,c{de,fh}}`</td><td>Matches a string from the string set {ab, cde, cfh}.</td></tr>
+</tbody>
+</table>


### PR DESCRIPTION
HTML tables left align cells by default.  Otherwise, the Supported Data Types table looks pretty similar.

The Hadoop Globs Patterns table makes better use of horizontal space and looks massively better.

I admit, writing tables in HTML is  a bit tedious.
