### PR TITLE
Improve table layout in pandoc output.

### DIFF
--- a/src/test/resources/runPandoc.sh
+++ b/src/test/resources/runPandoc.sh
@@ -13,5 +13,5 @@ mkdir -p $outDir
 
 for mdFile in $(find $inDir -name '*.md'); do
     mkdir -p $outDir$(dirname $mdFile)
-    pandoc $mdFile -f markdown -t html --mathjax --highlight-style=pygments -o $outDir${mdFile/%md/html}
+    pandoc $mdFile -f markdown -t html --mathjax --highlight-style=pygments --columns 10000 -o $outDir${mdFile/%md/html}
 done


### PR DESCRIPTION
Pandoc normally tries to manage wrapping in tables by setting column widths with a colgroup and width attributes.  This isn't necessary for HTML.  This change suppresses the colgroups.  Got the idea from here:

https://github.com/jgm/pandoc/issues/2574
