### PR TITLE
fix copy constructor for Genotype

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Genotype.scala
@@ -74,7 +74,7 @@ class Genotype(private val _gt: Int,
     gq: Option[Int] = this.gq,
     px: Option[Array[Int]] = this.px,
     fakeRef: Boolean = this.fakeRef,
-    isDosage: Boolean = this.isDosage): Genotype = Genotype(gt, ad, dp, gq, pl, fakeRef, isDosage)
+    isDosage: Boolean = this.isDosage): Genotype = Genotype(gt, ad, dp, gq, px, fakeRef, isDosage)
 
   override def equals(that: Any): Boolean = that match {
     case g: Genotype =>


### PR DESCRIPTION
We want to use the method argument `pl` rather than
always setting the result to `px`.