### PR TITLE
CSS Fixes

### DIFF
--- a/docs/pandocSampleTemplate.css
+++ b/docs/pandocSampleTemplate.css
@@ -118,14 +118,18 @@ hr {
   padding: 0;
 }
 
-pre, code, kbd, samp {
+pre, code, kdb, samp {
   color: #000;
   font-family: monospace, monospace;
   _font-family: 'courier new', monospace;
-  font-size: 0.98em;
   background: rgba(238, 238, 238, 1);
+}
+
+code, kbd, samp {
+  font-size: 80%;
   /* 5/32, 10/32 .15625em .3125em */
   padding: .15625em .25em;
+  display: inline-block;
 }
 
 pre {
@@ -364,7 +368,7 @@ body > div:not(.command) > *:not(h1):not(h2) {
 
 pre.synopsis {
     padding: 10px 10px 10px 60px;
-    text-indent: -50px;
+    text-indent: -25px;
     white-space: pre-wrap;
 }
 

--- a/docs/pandocSampleTemplate.css
+++ b/docs/pandocSampleTemplate.css
@@ -128,7 +128,7 @@ pre, code, kdb, samp {
 code, kbd, samp {
   font-size: 80%;
   /* 5/32, 10/32 .15625em .3125em */
-  padding: .15625em .25em;
+  padding: 0em .25em;
   display: inline-block;
 }
 


### PR DESCRIPTION
1. `inline-block` on `code` tags fixes code tags inside
   pre blocks having a little extra pading on the first line
   by applying the padding to each line

2. `font-size` is applied once using the `code` tag and is
   reduced to 80%

3. Some combination of the above broke the indentation hack
   for synposes; setting the `text-index` to -25 seems to restore
   the previous behavior.