### PR TITLE
make splitmulti use alt allele index

### DIFF
--- a/docs/Filtering.md
+++ b/docs/Filtering.md
@@ -52,7 +52,7 @@ filtervariants expr -c '!va.pass' --remove
 
 ```
 [after importvcf & splitmulti]
-filtervariants expr -c 'va.info.AC[va.aIndex] > 1' --keep 
+filtervariants expr -c 'va.info.AC[va.aIndex - 1] > 1' --keep 
 ```
 
 ```

--- a/docs/HailExpressionLanguage.md
+++ b/docs/HailExpressionLanguage.md
@@ -326,10 +326,10 @@ In the below expression, we will use a different cutoff for samples with Europea
 filtersamples expr --keep -c 'if (sa.ancestry == "EUR") sa.qc.nSingleton < 100 else sa.qc.nSingleton < 200'
 ```
 
-The below expression assumes a VDS was split from a VCF, and filters down to sites which were singletons on import.  `va.aIndex` indexes into the originally-multiallelic array `va.info.AC` with the original position of each variant.
+The below expression assumes a VDS was split from a VCF, and filters down to sites which were singletons on import.  `va.aIndex - 1` (NB: `va.aIndex` is the allele index, not the alternate allele index) indexes into the originally-multiallelic array `va.info.AC` with the original position of each variant.
 
 ```
-filtervariants expr --keep -c 'if (va.info.AC[va.aIndex]) == 1'
+filtervariants expr --keep -c 'if (va.info.AC[va.aIndex - 1]) == 1'
 ```
 
 See documentation on [exporting to TSV](#ExportTSV) for more examples of what Hail's language can do.

--- a/docs/commands/annotatevariants_expr.md
+++ b/docs/commands/annotatevariants_expr.md
@@ -11,17 +11,17 @@
 
 These expressions look something like the following:
 ```
-annotatevariants expr -c 'va.isSingleton = va.info.AC[va.aIndex] == 1'
+annotatevariants expr -c 'va.isSingleton = va.info.AC[va.aIndex - 1] == 1'
 ```
 
 To break down this expression:
 ```
 annotatevariants expr \
-   -c   "'va.isSingleton                    =           va.info.AC[va.aIndex] == 1'       [ , ... ]"
-                  ^                         ^                     ^                           ^
-         *period-delimited path         equals sign            expression             (optional) comma 
-       starting with 'va'              delimits path                                  followed by more 
-       where the annotation will      and expression                                annotation statements
+   -c   "'va.isSingleton                    =           va.info.AC[va.aIndex - 1] == 1'       [ , ... ]"
+                  ^                         ^                       ^                             ^
+         *period-delimited path         equals sign             expression                 (optional) comma 
+       starting with 'va'              delimits path                                       followed by more 
+       where the annotation will      and expression                                     annotation statements
              be placed
 ```
 

--- a/docs/commands/splitmulti.md
+++ b/docs/commands/splitmulti.md
@@ -100,12 +100,12 @@ A	T	0/1:10,6:16:50:50,0,99
 <div class="cmdsubsection">
 ### VCF Info Fields:
 
-Hail does not split annotations in the info field.  This means that if a multiallelic site with info.AC value `[10, 2]` is split, each split site will contain the same array `[10, 2]`.  The provided annotation `va.aIndex` can be used to select the value corresponding to the split allele's position:
+Hail does not split annotations in the info field.  This means that if a multiallelic site with info.AC value `[10, 2]` is split, each split site will contain the same array `[10, 2]`.  The provided allele index annotation `va.aIndex` can be used to select the value corresponding to the split allele's position:
 
 ```
 $ hail importvcf 1kg.vcf.bgz
     splitmulti
-    filtervariants expr -c 'va.info.AC[va.aIndex] < 10' --remove
+    filtervariants expr -c 'va.info.AC[va.aIndex - 1] < 10' --remove
 ```
 
 **VCFs split by Hail and exported to new VCFs may be incompatible with other tools, if action is not taken first.**  Since the "Number" of the arrays in split multiallelic sites no longer matches the structure on import ("A" for 1 per allele, for example), Hail will export these fields with number ".".
@@ -115,7 +115,7 @@ If the desired output is one value per site, then it is possible to use `annotat
 ```
 $ hail importvcf 1kg.vcf.bgz
     splitmulti 
-    annotatevariants expr -c 'va.info.AC = va.info.AC[va.aIndex]'
+    annotatevariants expr -c 'va.info.AC = va.info.AC[va.aIndex - 1]'
     exportvcf -o 1kg.split.vcf.bgz
 ```
 
@@ -125,6 +125,7 @@ After this pipeline, the info field "AC" in `1kg.split.vcf.bgz` will have number
 <div class="cmdsubsection">
 ### <a name="splitmulti_annotations"></a> Annotations:
 
- - `va.wasSplit       Boolean` -- this variant was originally multiallelic 
- - `va.aIndex             Int` -- The original index of this variant in imported line, 0 for imported biallelic sites
+ - `va.wasSplit : Boolean` -- this variant was originally multiallelic
+ - `va.aIndex : Int` -- the original index of this alternate allele in the multiallelic representation (NB: 1 is the first alternate allele or the only alternate allele in a biallelic variant). For example, `1:100:A:T,C` yields two instances: `1:100:A:T` with aIndex = 1 and `1:100:A:C` with aIndex = 2.
+
 </div>

--- a/src/main/scala/org/broadinstitute/hail/driver/SplitMulti.scala
+++ b/src/main/scala/org/broadinstitute/hail/driver/SplitMulti.scala
@@ -72,10 +72,10 @@ object SplitMulti extends Command {
 
     val splitVariants = v.altAlleles.iterator.zipWithIndex
       .filter(_._1.alt != "*")
-      .map { case (aa, i) =>
+      .map { case (aa, aai) =>
         val (newStart, newRef, newAlt) = minRep(v.start, v.ref, aa.alt)
 
-        (Variant(v.contig, newStart, newRef, newAlt), i + 1)
+        (Variant(v.contig, newStart, newRef, newAlt), aai + 1)
       }.toArray.sorted
 
     val splitGenotypeBuilders = splitVariants.map { case (sv, _) => new GenotypeBuilder(sv.nAlleles, isDosage) }
@@ -154,7 +154,7 @@ object SplitMulti extends Command {
     splitVariants.iterator
       .zip(splitGenotypeStreamBuilders.iterator)
       .map { case ((v, ind), gsb) =>
-        (v, (insertSplitAnnots(va, ind - 1, true), gsb.result()))
+        (v, (insertSplitAnnots(va, ind, true), gsb.result()))
       }
   }
 

--- a/src/main/scala/org/broadinstitute/hail/expr/AST.scala
+++ b/src/main/scala/org/broadinstitute/hail/expr/AST.scala
@@ -1902,7 +1902,7 @@ case class IndexOp(posn: Position, f: AST, idx: AST) extends AST(posn, Array(f, 
             ParserUtils.error(localPos,
               s"""Tried to access index [$i] on array ${ JsonMethods.compact(localT.toJSON(a)) } of length ${ a.length }
                   |  Hint: All arrays in Hail are zero-indexed (`array[0]' is the first element)
-                  |  Hint: For accessing `A'-numbered info fields in split variants, `va.info.field[va.aIndex]' is correct""".stripMargin)
+                  |  Hint: For accessing `A'-numbered info fields in split variants, `va.info.field[va.aIndex - 1]' is correct""".stripMargin)
           case e: Throwable => throw e
         })
 


### PR DESCRIPTION
This modifies existing behavior where `aIndex` meant the
alt allele index (e.g. 0 is the first alternate). We are
modifying this behavior across all of hail such that
`aIndex` refers to the *allele* index (e.g. 0 is the
reference).