### PR TITLE
Explicitly set the rootProject.name to 'hail'

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name='hail'


### PR DESCRIPTION
The default is to use the cloned repo directory name, but this may be something other than 'hail'.