### PR TITLE
Fix sorted VCF import bugs.

### DIFF
--- a/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedRDD.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/OrderedRDD.scala
@@ -16,6 +16,7 @@ object OrderedRDD {
 
   def apply[T, K, V](rdd: RDD[(K, V)], projectKey: (K) => T, fastKeys: Option[RDD[K]] = None)
     (implicit tOrd: Ordering[T], kOrd: Ordering[K], tct: ClassTag[T], kct: ClassTag[K]): OrderedRDD[T, K, V] = {
+    import Ordering.Implicits._
 
     if (rdd.partitions.isEmpty)
       return empty(rdd.sparkContext, projectKey)
@@ -42,8 +43,8 @@ object OrderedRDD {
 
     val partitionsSorted =
       keyInfoOption.exists(keyInfo =>
-        keyInfo.tail.zip(keyInfo).forall { case (pi1, pi2) =>
-          tOrd.lt(pi1.max, pi2.min)
+        keyInfo.zip(keyInfo.tail).forall { case (p, pnext) =>
+          p.max < pnext.min
         })
 
     if (partitionsSorted) {

--- a/src/main/scala/org/broadinstitute/hail/sparkextras/PartitionKeyInfo.scala
+++ b/src/main/scala/org/broadinstitute/hail/sparkextras/PartitionKeyInfo.scala
@@ -12,6 +12,8 @@ object PartitionKeyInfo {
   final val KSORTED = 2
 
   def apply[T, K](partIndex: Int, projectKey: (K) => T, it: Iterator[K])(implicit tOrd: Ordering[T], kOrd: Ordering[K]): PartitionKeyInfo[T] = {
+    import Ordering.Implicits._
+
     assert(it.hasNext)
 
     val k0 = it.next()
@@ -27,14 +29,14 @@ object PartitionKeyInfo {
       val k = it.next()
       val t = projectKey(k)
 
-      if (tOrd.lt(prevT, t))
+      if (t < prevT)
         sortedness = UNSORTED
-      else if (kOrd.lt(prevK, k))
+      else if (k < prevK)
         sortedness = sortedness.min(TSORTED)
 
-      if (tOrd.lt(t, minT))
+      if (t < minT)
         minT = t
-      if (tOrd.gt(t, maxT))
+      if (t > maxT)
         maxT = t
 
       prevK = k

--- a/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
+++ b/src/main/scala/org/broadinstitute/hail/variant/Variant.scala
@@ -10,17 +10,15 @@ import org.json4s._
 import scala.math.Numeric.Implicits._
 
 object Contig {
+  val standardContigs = (1 to 23).map(_.toString) ++ IndexedSeq("X", "Y", "MT")
+  val standardContigIdx = standardContigs.zipWithIndex.toMap
+
   def compare(lhs: String, rhs: String): Int = {
-    if (lhs.forall(_.isDigit)) {
-      if (rhs.forall(_.isDigit)) {
-        lhs.toInt.compare(rhs.toInt)
-      } else
-        -1
-    } else {
-      if (rhs.forall(_.isDigit))
-        1
-      else
-        lhs.compare(rhs)
+    (standardContigIdx.get(lhs), standardContigIdx.get(rhs)) match {
+      case (Some(i), Some(j)) => i.compare(j)
+      case (Some(_), None) => -1
+      case (None, Some(_)) => 1
+      case (None, None) => lhs.compare(rhs)
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/hail/variant/VariantSuite.scala
+++ b/src/test/scala/org/broadinstitute/hail/variant/VariantSuite.scala
@@ -5,8 +5,8 @@ import org.testng.annotations.Test
 
 class VariantSuite extends TestNGSuite {
   @Test def test() {
-    assert(Contig.compare("3", "26") < 0)
-    assert(Contig.compare("26", "3") > 0)
+    assert(Contig.compare("3", "18") < 0)
+    assert(Contig.compare("18", "3") > 0)
     assert(Contig.compare("7", "7") == 0)
 
     assert(Contig.compare("3", "X") < 0)
@@ -15,6 +15,10 @@ class VariantSuite extends TestNGSuite {
 
     assert(Contig.compare("X", "Y") < 0)
     assert(Contig.compare("Y", "X") > 0)
-    assert(Contig.compare("MT", "Y") < 0)
+    assert(Contig.compare("Y", "MT") < 0)
+
+    assert(Contig.compare("18", "SPQR") < 0)
+    assert(Contig.compare("MT", "SPQR") < 0)
+
   }
 }


### PR DESCRIPTION
Sort 1 ... 23, X, Y, MT first, in that order, and then other chromosomes.
Fixed comparisons in OrderedRDD.
Verified on a non-trivial dataset.