### PR TITLE
removed source/targetcompatibility from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,9 +241,6 @@ task wrapper(type: Wrapper) {
     gradleVersion = '2.14.1'
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
-
 task setupDocs(type: Exec) {
     commandLine 'mkdir', '-p', 'build/docs/js/', 'build/docs/html/', 'build/docs/resources/', 'build/docs/css/'
 }


### PR DESCRIPTION
These were greyed out and default to the project source and target compatability:
https://docs.gradle.org/current/dsl/org.gradle.api.tasks.scala.ScalaCompile.html#org.gradle.api.tasks.scala.ScalaCompile:sourceCompatibility

Removing these lines kills the warning:
`warning: [options] bootstrap class path not set in conjunction with -source 1.7`